### PR TITLE
Iterate over lsdrive output to get detailed information from the drive

### DIFF
--- a/plugins/modules/ibm_svc_info.py
+++ b/plugins/modules/ibm_svc_info.py
@@ -638,6 +638,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ibm.storage_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi, svc_argument_spec, get_logger
 from ansible.module_utils._text import to_native
 
+import time
+
 
 class IBMSVCGatherInfo(object):
     def __init__(self):
@@ -761,6 +763,15 @@ class IBMSVCGatherInfo(object):
                 output[op_key] = self.restapi.svc_obj_info(cmd=cmd,
                                                            cmdopts=None,
                                                            cmdargs=cmdargs)
+                if cmd == "lsdrive":
+                    drive = []
+                    for d in output[op_key]:
+                        self.log.info("log iteration %s", d["id"])
+                        cmdargs = [d["id"]]
+                        time.sleep(0.08)
+                        d.update(self.restapi.svc_obj_info(cmd=cmd,
+                                                               cmdopts=None,
+                                                               cmdargs=cmdargs))            
             self.log.info('Successfully listed %d %s info '
                           'from cluster %s', len(subset), subset,
                           self.module.params['clustername'])


### PR DESCRIPTION
##### SUMMARY
Add detail information to Drives via lsdrive detail api call.

#Fixes #26

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
ibm_svc_info

##### ADDITIONAL INFORMATION
Add details like firmware information from each drive when calling lsdrive.
Uses a Sleep Timer because we are getting issues with "request quota reached" errors otherwise.