### PR TITLE
Allowing user to transform volumes between Thin and Thick/Generic provisioning and migrate a volume to a different pool using Volume Mirror

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.analysis.extraPaths": [
+        "./plugins/modules"
+    ]
+}

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,8 +1,8 @@
 # See https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html
 
-namespace: ibm
+namespace: irw
 name: storage_virtualize
-version: 2.1.0
+version: 2.1.1
 readme: README.md
 authors:
   - Shilpi Jain (github.com/Shilpi-J)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,8 +1,8 @@
 # See https://docs.ansible.com/ansible/latest/dev_guide/collections_galaxy_meta.html
 
-namespace: irw
+namespace: ibm
 name: storage_virtualize
-version: 2.1.1
+version: 2.2.0
 readme: README.md
 authors:
   - Shilpi Jain (github.com/Shilpi-J)

--- a/plugins/module_utils/ibm_svc_utils.py
+++ b/plugins/module_utils/ibm_svc_utils.py
@@ -16,6 +16,10 @@ from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 
+# from urllib import open_url
+# from six import quote
+# from six import HTTPError
+
 
 def svc_argument_spec():
     """

--- a/plugins/modules/ibm_svc_manage_mirrored_volume.py
+++ b/plugins/modules/ibm_svc_manage_mirrored_volume.py
@@ -631,6 +631,8 @@ update the topolgy from standard mirror to HyperSwap")
             cmdopts['rsize'] = self.rsize
         elif self.thin:
             cmdopts['rsize'] = "2%"
+            # Set autoexpand to true. Short of having an autoexpand setting this should be the case for any thin volume
+            cmdopts['autoexpand'] = True
         elif self.rsize and not self.thin:
             self.module.fail_json(msg="To configure 'rsize', parameter 'thin' should be passed and the value should be 'true'.")
         if self.deduplicated:

--- a/plugins/modules/ibm_svc_manage_mirrored_volume.py
+++ b/plugins/modules/ibm_svc_manage_mirrored_volume.py
@@ -70,6 +70,9 @@ options:
       a "standard mirror" volume gets created.
     - If a "standard" mirrored volume exists and either I(PoolA) or I(PoolB)
       is specified, the mirrored volume gets converted to a standard volume.
+    - Transform allows a volume to be changed between thin and thick/generic provisioning and automatically deletes the old copy after sync
+    - Transform also allows Volume Mirror to be used for migration between pools. A volume will move to a different pool (within the same IO Group for non-disruption)
+      and the original copy will be deleted after synchronization
     choices: [ local hyperswap, standard, transform ]
     type: str
   thin:

--- a/plugins/modules/ibm_svc_manage_mirrored_volume.py
+++ b/plugins/modules/ibm_svc_manage_mirrored_volume.py
@@ -413,7 +413,7 @@ update the topolgy from standard mirror to HyperSwap")
         if self.vdisk_type == "local hyperswap" and self.expand_flag:
             cmd = "expandvolume"
         elif self.vdisk_type == "local hyperswap" and self.shrink_flag:
-            self.module.fail_json(msg="Size of a HyperSwap Volume cannot be shrinked")
+            self.module.fail_json(msg="A HyperSwap Volume cannot be reduced in size")
         elif self.vdisk_type == "standard mirror" and self.expand_flag:
             cmd = "expandvdisksize"
         elif self.vdisk_type == "standard mirror" and self.shrink_flag:

--- a/plugins/modules/ibm_svc_manage_volume.py
+++ b/plugins/modules/ibm_svc_manage_volume.py
@@ -139,6 +139,13 @@ options:
     type: bool
     default: false
     version_added: '2.0.0'
+  format_disk:
+    description:
+      - If set to `False`, will create a volume using 'mkvdisk' instead of 'mkvolume' and set `nofmtdisk` to true
+      - Valid only when volume groups are not used (only available in mkvolume)
+    type: bool
+    default: true
+    version_added: 'tbd'
   validate_certs:
     description:
       - Validates certification.
@@ -255,6 +262,7 @@ EXAMPLES = '''
     state: "absent"
 '''
 
+
 RETURN = '''#'''
 
 from traceback import format_exc
@@ -291,7 +299,8 @@ class IBMSVCvolume(object):
                 old_name=dict(type='str', required=False),
                 enable_cloud_snapshot=dict(type='bool'),
                 cloud_account_name=dict(type='str'),
-                allow_hs=dict(type='bool', default=False)
+                allow_hs=dict(type='bool', default=False),
+                format_disk=dict(type='bool', default=True)
             )
         )
 
@@ -321,6 +330,7 @@ class IBMSVCvolume(object):
         self.enable_cloud_snapshot = self.module.params['enable_cloud_snapshot']
         self.cloud_account_name = self.module.params['cloud_account_name']
         self.allow_hs = self.module.params['allow_hs']
+        self.format_disk = self.module.params['format_disk']
 
         # internal variable
         self.changed = False
@@ -366,6 +376,9 @@ class IBMSVCvolume(object):
             self.module.fail_json(msg='Missing mandatory parameter: [{0}]'.format(', '.join(missing)))
         if self.volumegroup and self.novolumegroup:
             self.module.fail_json(msg='Mutually exclusive parameters detected: [volumegroup] and [novolumegroup]')
+        elif self.volumegroup and self.format_disk:
+            # volumegroup is only available in mkvolume, so cannot be used with format_disk
+            self.module.fail_json(msg='Mutually exclusive parameters detected: [volumegroup] and [format_disk]')
 
     # for validating parameter while removing an existing volume
     def volume_deletion_parameter_validation(self):
@@ -445,35 +458,71 @@ class IBMSVCvolume(object):
         if self.module.check_mode:
             self.changed = True
             return
-        cmd = 'mkvolume'
-        cmdopts = {}
-        if self.pool:
-            cmdopts['pool'] = self.pool
-        if self.size:
-            cmdopts['size'] = self.size
-        if self.unit:
-            cmdopts['unit'] = self.unit
-        if self.iogrp:
-            cmdopts['iogrp'] = self.iogrp[0]
-        if self.volumegroup:
-            cmdopts['volumegroup'] = self.volumegroup
-        if self.thin:
-            cmdopts['thin'] = self.thin
-        if self.compressed:
-            cmdopts['compressed'] = self.compressed
-        if self.deduplicated:
-            cmdopts['deduplicated'] = self.deduplicated
-        if self.buffersize:
-            cmdopts['buffersize'] = self.buffersize
-        if self.name:
-            cmdopts['name'] = self.name
-        result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
-        if result and 'message' in result:
-            self.changed = True
-            self.log("create volume result message %s", result['message'])
+        if self.format_disk != False:
+        # if the format_disk parameter isn't false then it's fine to use addvolume as normal
+            cmd = 'mkvolume'
+            cmdopts = {}
+            if self.pool:
+                cmdopts['pool'] = self.pool
+            if self.size:
+                cmdopts['size'] = self.size
+            if self.unit:
+                cmdopts['unit'] = self.unit
+            if self.iogrp:
+                cmdopts['iogrp'] = self.iogrp[0]
+            if self.volumegroup:
+                cmdopts['volumegroup'] = self.volumegroup
+            if self.thin:
+                cmdopts['thin'] = self.thin
+            if self.compressed:
+                cmdopts['compressed'] = self.compressed
+            if self.deduplicated:
+                cmdopts['deduplicated'] = self.deduplicated
+            if self.buffersize:
+                cmdopts['buffersize'] = self.buffersize
+            if self.name:
+                cmdopts['name'] = self.name
+            result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+            if result and 'message' in result:
+                self.changed = True
+                self.log("create volume result message %s", result['message'])
+            else:
+                self.module.fail_json(
+                    msg="Failed to create volume [%s]" % self.name)
         else:
-            self.module.fail_json(
-                msg="Failed to create volume [%s]" % self.name)
+        # if format_disk is false, then mkvdisk is used and the volume will be created without formatting
+            cmd = 'mkvdisk'
+            cmdopts = {}
+            if self.pool:
+                cmdopts['mdiskgrp'] = self.pool
+            if self.size:
+                cmdopts['size'] = self.size
+            if self.unit:
+                cmdopts['unit'] = self.unit
+            if self.iogrp:
+                cmdopts['iogrp'] = self.iogrp[0]
+            # volume group not supported with mkvdisk
+            # if self.volumegroup:
+            #     cmdopts['volumegroup'] = self.volumegroup
+            if self.thin:
+                cmdopts['thin'] = self.thin
+            if self.compressed:
+                cmdopts['compressed'] = self.compressed
+            if self.deduplicated:
+                cmdopts['deduplicated'] = self.deduplicated
+            if self.buffersize:
+                cmdopts['rsize'] = self.buffersize
+            if self.name:
+                cmdopts['name'] = self.name
+            cmdopts['nofmtdisk'] = True
+            # nofmtdisk can be set without any prior test because it's already been tested
+            result = self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+            if result and 'message' in result:
+                self.changed = True
+                self.log("create volume result message %s", result['message'])
+            else:
+                self.module.fail_json(
+                    msg="Failed to create volume [%s]" % self.name)
 
     # function to remove an existing volume
     def remove_volume(self):

--- a/plugins/modules/ibm_svc_manage_volume.py
+++ b/plugins/modules/ibm_svc_manage_volume.py
@@ -535,17 +535,21 @@ class IBMSVCvolume(object):
                 }
         # check for change in -thin parameter
         if self.thin is not None:
-            if self.thin is True:
+            if self.thin is True and (data[1]['se_copy'] == 'no' or data[1]['compressed_copy'] == 'yes'):
                 # a standard volume or a compressed volume
-                if (data[0]['capacity'] == data[1]['real_capacity']) or (data[1]['compressed_copy'] == 'yes'):
-                    props['thin'] = {
-                        'status': True
-                    }
-            else:
-                if (data[0]['capacity'] != data[1]['real_capacity']) or (data[1]['compressed_copy'] == 'no'):
-                    props['thin'] = {
-                        'status': True
-                    }
+                # if (int(data[0]['capacity']) == data[1]['real_capacity']) or (data[1]['compressed_copy'] == 'yes'):
+                # changed logic to use se_copy instead of comparing values
+                props['thin'] = {
+                    'status': True
+                }
+                self.log('value of self.thin %s', self.thin )
+
+            # Removed compare with compressed_copy. A volume can be compressed_copy = 'no' with se_copy = 'yes' so this would always be 
+            # True if self.thin was False
+            elif (self.thin is False and data[1]['se_copy'] == 'yes'):
+                props['thin'] = {
+                    'status': True
+                }
         # check for change in -compressed parameter
         if self.compressed is True:
             # not a compressed volume

--- a/plugins/modules/ibm_svc_utils.py
+++ b/plugins/modules/ibm_svc_utils.py
@@ -1,0 +1,334 @@
+# Copyright (C) 2020 IBM CORPORATION
+# Author(s): Peng Wang <wangpww@cn.ibm.com>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+""" Support class for IBM SVC ansible modules """
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+import logging
+
+from ansible.module_utils.urls import open_url
+from ansible.module_utils.six.moves.urllib.parse import quote
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+
+# from urllib import open_url
+# from six import quote
+# from six import HTTPError
+
+
+def svc_argument_spec():
+    """
+    Returns argument_spec of options common to ibm_svc_*-modules
+
+    :returns: argument_spec
+    :rtype: dict
+    """
+    return dict(
+        clustername=dict(type='str', required=True),
+        domain=dict(type='str', default=None),
+        validate_certs=dict(type='bool', default=False),
+        username=dict(type='str'),
+        password=dict(type='str', no_log=True),
+        log_path=dict(type='str'),
+        token=dict(type='str', no_log=True)
+    )
+
+
+def svc_ssh_argument_spec():
+    """
+    Returns argument_spec of options common to ibm_svcinfo_command
+    and ibm_svctask_command modules
+
+    :returns: argument_spec
+    :rtype: dict
+    """
+    return dict(
+        clustername=dict(type='str', required=True),
+        username=dict(type='str', required=True),
+        password=dict(type='str', required=True, no_log=True),
+        log_path=dict(type='str')
+    )
+
+
+def strtobool(val):
+    '''
+    Converts a string representation to boolean.
+
+    This is a built-in function available in python till the version 3.9 under disutils.util
+    but this has been deprecated in 3.10 and may not be available in future python releases
+    so adding the source code here.
+    '''
+    if val in {'y', 'yes', 't', 'true', 'on', '1'}:
+        return 1
+    elif val in {'n', 'no', 'f', 'false', 'off', '0'}:
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
+
+
+def get_logger(module_name, log_file_name, log_level=logging.INFO):
+    FORMAT = '%(asctime)s.%(msecs)03d %(levelname)5s %(thread)d %(filename)s:%(funcName)s():%(lineno)s %(message)s'
+    DATEFORMAT = '%Y-%m-%dT%H:%M:%S'
+    log_path = 'IBMSV_ansible_collections.log'
+    if log_file_name:
+        log_path = log_file_name
+    logging.basicConfig(filename=log_path, format=FORMAT, datefmt=DATEFORMAT)
+    log = logging.getLogger(module_name)
+    log.setLevel(log_level)
+    return log
+
+
+class IBMSVCRestApi(object):
+    """ Communicate with SVC through RestApi
+    SVC commands usually have the format
+    $ command -opt1 value1 -opt2 value2 arg1 arg2 arg3
+    to use the RestApi we transform this into
+    https://host:7443/rest/command/arg1/arg2/arg3
+    data={'opt1':'value1', 'opt2':'value2'}
+    """
+
+    def __init__(self, module, clustername, domain, username, password,
+                 validate_certs, log_path, token):
+        """ Initialize module with what we need for initial connection
+        :param clustername: name of the SVC cluster
+        :type clustername: string
+        :param domain: domain name to make a fully qualified host name
+        :type domain: string
+        :param username: SVC username
+        :type username: string
+        :param password: Password for user
+        :type password: string
+        :param validate_certs: whether or not the connection is insecure
+        :type validate_certs: bool
+        """
+        self.module = module
+        self.clustername = clustername
+        self.domain = domain
+        self.username = username
+        self.password = password
+        self.validate_certs = validate_certs
+        self.token = token
+
+        # logging setup
+        log = get_logger(self.__class__.__name__, log_path)
+        self.log = log.info
+
+        # Make sure we can connect through the RestApi
+        if self.token is None:
+            if not self.username or not self.password:
+                self.module.fail_json(msg="You must pass in either pre-acquired token"
+                                          " or username/password to generate new token")
+            self.token = self._svc_authorize()
+        else:
+            self.log("Token already passed: %s", self.token)
+
+        if not self.token:
+            self.module.exit_json(msg='Failed to obtain access token', unreachable=True)
+
+    @property
+    def port(self):
+        return getattr(self, '_port', None) or '7443'
+
+    @property
+    def protocol(self):
+        return getattr(self, '_protocol', None) or 'https'
+
+    @property
+    def resturl(self):
+        if self.domain:
+            hostname = '%s.%s' % (self.clustername, self.domain)
+        else:
+            hostname = self.clustername
+        return (getattr(self, '_resturl', None)
+                or "{protocol}://{host}:{port}/rest".format(
+                    protocol=self.protocol, host=hostname, port=self.port))
+
+    @property
+    def token(self):
+        return getattr(self, '_token', None) or None
+
+    @token.setter
+    def token(self, value):
+        return setattr(self, '_token', value)
+
+    def _svc_rest(self, method, headers, cmd, cmdopts, cmdargs, timeout=10):
+        """ Run SVC command with token info added into header
+        :param method: http method, POST or GET
+        :type method: string
+        :param headers: http headers
+        :type headers: dict
+        :param cmd: svc command to run
+        :type cmd: string
+        :param cmdopts: svc command options, name paramter and value
+        :type cmdopts: dict
+        :param cmdargs: svc command arguments, non-named paramaters
+        :type timeout: int
+        :param timeout: open_url argument to set timeout for http gateway
+        :return: dict of command results
+        :rtype: dict
+        """
+
+        # Catch any output or errors and pass back to the caller to deal with.
+        r = {
+            'url': None,
+            'code': None,
+            'err': None,
+            'out': None,
+            'data': None
+        }
+
+        postfix = cmd
+        if cmdargs:
+            postfix = '/'.join([postfix] + [quote(str(a)) for a in cmdargs])
+        url = '/'.join([self.resturl] + [postfix])
+        r['url'] = url  # Pass back in result for error handling
+        self.log("_svc_rest: url=%s", url)
+
+        payload = cmdopts if cmdopts else None
+        data = self.module.jsonify(payload).encode('utf8')
+        r['data'] = cmdopts  # Original payload data has nicer formatting
+        self.log("_svc_rest: payload=%s", payload)
+
+        try:
+            o = open_url(url, method=method, headers=headers, timeout=timeout,
+                         validate_certs=self.validate_certs, data=bytes(data))
+        except HTTPError as e:
+            self.log('_svc_rest: httperror %s', str(e))
+            r['code'] = e.getcode()
+            r['out'] = e.read()
+            r['err'] = "HTTPError %s", str(e)
+            return r
+        except Exception as e:
+            self.log('_svc_rest: exception : %s', str(e))
+            r['err'] = "Exception %s", str(e)
+            return r
+
+        try:
+            j = json.load(o)
+        except ValueError as e:
+            self.log("_svc_rest: value error pass: %s", str(e))
+            # pass, will mean both data and error are None.
+            return r
+
+        r['out'] = j
+        return r
+
+    def _svc_authorize(self):
+        """ Obtain a token if we are authoized to connect
+        :return: None or token string
+        """
+
+        headers = {
+            'Content-Type': 'application/json',
+            'X-Auth-Username': self.username,
+            'X-Auth-Password': self.password
+        }
+
+        rest = self._svc_rest(method='POST', headers=headers, cmd='auth',
+                              cmdopts=None, cmdargs=None)
+
+        if rest['err']:
+            return None
+
+        out = rest['out']
+        if out:
+            if 'token' in out:
+                return out['token']
+
+        return None
+
+    def _svc_token_wrap(self, cmd, cmdopts, cmdargs, timeout=10):
+        """ Run SVC command with token info added into header
+        :param cmd: svc command to run
+        :type cmd: string
+        :param cmdopts: svc command options, name paramter and value
+        :type cmdopts: dict
+        :param cmdargs: svc command arguments, non-named paramaters
+        :type cmdargs: list
+        :param timeout: open_url argument to set timeout for http gateway
+        :type timeout: int
+        :returns: command results
+        """
+
+        if self.token is None:
+            self.module.fail_json(msg="No authorize token")
+            # Abort
+
+        headers = {
+            'Content-Type': 'application/json',
+            'X-Auth-Token': self.token
+        }
+
+        return self._svc_rest(method='POST', headers=headers, cmd=cmd,
+                              cmdopts=cmdopts, cmdargs=cmdargs, timeout=timeout)
+
+    def svc_run_command(self, cmd, cmdopts, cmdargs, timeout=10):
+        """ Generic execute a SVC command
+        :param cmd: svc command to run
+        :type cmd: string
+        :param cmdopts: svc command options, name parameter and value
+        :type cmdopts: dict
+        :param cmdargs: svc command arguments, non-named parameters
+        :type cmdargs: list
+        :param timeout: open_url argument to set timeout for http gateway
+        :type timeout: int
+        :returns: command output
+        """
+
+        rest = self._svc_token_wrap(cmd, cmdopts, cmdargs, timeout)
+        self.log("svc_run_command rest=%s", rest)
+
+        if rest['err']:
+            msg = rest
+            self.module.fail_json(msg=msg)
+            # Aborts
+
+        # Might be None
+        return rest['out']
+
+    def svc_obj_info(self, cmd, cmdopts, cmdargs, timeout=10):
+        """ Obtain information about an SVC object through the ls command
+        :param cmd: svc command to run
+        :type cmd: string
+        :param cmdopts: svc command options, name parameter and value
+        :type cmdopts: dict
+        :param cmdargs: svc command arguments, non-named paramaters
+        :type cmdargs: list
+        :param timeout: open_url argument to set timeout for http gateway
+        :type timeout: int
+        :returns: command output
+        :rtype: dict
+        """
+
+        rest = self._svc_token_wrap(cmd, cmdopts, cmdargs, timeout)
+        self.log("svc_obj_info rest=%s", rest)
+
+        if rest['code']:
+            if rest['code'] == 500:
+                # Object did not exist, which is quite valid.
+                return None
+
+        # Fail for anything else
+        if rest['err']:
+            self.module.fail_json(msg=rest)
+            # Aborts
+
+        # Might be None
+        return rest['out']
+
+    def get_auth_token(self):
+        """ Obtain information about an SVC object through the ls command
+        :returns: authentication token
+        """
+        # Make sure we can connect through the RestApi
+        self.token = self._svc_authorize()
+        self.log("_connect by using token")
+        if not self.token:
+            self.module.exit_json(msg='Failed to obtain access token', unreachable=True)
+
+        return self.token

--- a/tests/unit/plugins/modules/test_ibm_svc_manage_migration.py
+++ b/tests/unit/plugins/modules/test_ibm_svc_manage_migration.py
@@ -3,9 +3,9 @@
 #
 # GNU General Public License v3.0+
 # (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 """ unit tests IBM Storage Virtualize Ansible module: ibm_svc_manage_migration """
-
+""" unit tests IBM Storage Virtualize Ansible module: ibm_svc_manage_migration """
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 import unittest

--- a/tests/unit/plugins/modules/test_ibm_svc_manage_mirrored_volume.py
+++ b/tests/unit/plugins/modules/test_ibm_svc_manage_mirrored_volume.py
@@ -14,8 +14,11 @@ import json
 from mock import patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
-from ansible_collections.ibm.storage_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi
-from ansible_collections.ibm.storage_virtualize.plugins.modules.ibm_svc_manage_mirrored_volume import IBMSVCvolume
+# from ansible_collections.ibm.storage_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi
+# from ansible_collections.ibm.storage_virtualize.plugins.modules.ibm_svc_manage_mirrored_volume import IBMSVCvolume
+from ibm_svc_utils import IBMSVCRestApi
+from ibm_svc_manage_mirrored_volume import IBMSVCvolume
+
 
 
 def set_module_args(args):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Updated to allow changing of a volume between Thin and Thick/Generic provisioning. This also allows a user to migrate a volume between pools in an IO Group using Volume Mirroring.

Additionally, when a user attempts to resize a hyperswap volume in the manage mirror module, the error message used the word "shrinked", which isn't proper english. I edited the message for clarity and flow.

Fixes #32 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ibm_svc_manage_mirrored_volume.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The GUI and the CLI of Storage Virtualize allow a user to convert a volume between Thick and Thin provisioning. On the back end, of the GUI this uses Volume Mirroring. If you use the capability in the GUI, you never see anything happen. In the CLI this is done by setting the -autodelete flag in the command.
This capability does not exist in the current version of the ibm_svc_manage_mirrored_volume.py module, however. The module requires that the volumes be in different pools and does not allow for -autodelete. As a result, the mirrored volume module only really works if your intent is to maintain the mirrored volumes for some sort of availability purpose (hyperswap or standard).
My change introduces a new "state" parameter option. "transform". 
An unmirrored volume with "transform" set as the desired state can create a new vdisk copy within the same pool. The new vdisk can be set to be thin/thick as needed. It will also allow migration of the volume to a different pool, including a DRP, or back from a DRP (if performance isn't working out, for example). When the synchronization is complete, the original copy of the volume will be deleted automatically, leaving only the new form of the volume in whichever pool was required.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
original bugfix/grammar fix:
before: "Size of a HyperSwap Volume cannot be shrinked"
after: "A HyperSwap Volume cannot be reduced in size"

Transform:
before: "Volume [test] already exists, no modifications done"
     It also would not have set autodelete if you created a vdisk in a different pool and would have left a volume mirror in place.
after: localhost Volume [test] is being transformed. The original copy will be deleted after synchronization
```
