### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cryptography >= '42.0.5'
-paramiko >= '3.4.0'
-python_version >= '3.9'
+cryptography>=42.0.5
+paramiko>=3.4.0
+python_version>=3.9


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Problems during the installation:

52.16 + /usr/bin/python3 -m pip install --cache-dir=/output/wheels -r /tmp/src/requirements.txt
52.58 ERROR: Invalid requirement: "cryptography >= '42.0.5'": Expected end or semicolon (after name and no valid version specifier)
52.58     cryptography >= '42.0.5'

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
