### PR TITLE
Resolve ibm_svc_info crashes (#60)

### DIFF
--- a/plugins/modules/ibm_svc_info.py
+++ b/plugins/modules/ibm_svc_info.py
@@ -1357,7 +1357,7 @@ class IBMSVCGatherInfo(object):
             'availablepatch': ('Availablepatch', 'lsavailablepatch', False, '8.7.0.0'),
             'patch': ('Patch', 'lspatch', False, '8.5.4.0'),
             'systempatches': ('Systempatches', 'lssystempatches', False, '8.5.4.0'),
-            'flashgrid': ('FlashsystemGrid', 'lsflashgrid', False, '8..7.1.0'),
+            'flashgrid': ('FlashsystemGrid', 'lsflashgrid', False, '8.7.1.0'),
             'flashgridmembers': ('FlashsystemGridMembers', 'lsflashgridmembers', False, '8.7.2.0'),
             'flashgridsystem': ('FlashsystemGridSystem', 'lsflashgridsystem', False, '8.7.3.0'),
             'flashgridpartition': ('FlashsystemGridPartition', 'lsflashgridpartition', False, '8.7.2.0')


### PR DESCRIPTION
##### SUMMARY
Fixes #60 

The cmd_mappings dict in the apply() function had a double '.' in the line for lsflashgrid. This resulted in an empty string when the value was split on '.', and the empty string cannot be evaluated by int().

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
