### PR TITLE
SV ansible collection release 3.2.0 changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,25 @@ IBM Storage Virtualize Release Notes
 
 .. contents:: Topics
 
+v3.2.0
+======
+
+Release Summary
+---------------
+
+Added support for looging in using the partition IP address across volume, volumegroup, host, hostcluster, snapshot, replication, and GAM modules, modified partition_migration_host_actions playbook for iSCSI hosts and added support for volume parameters autoexpand, preferrednode and cache.
+
+Minor Changes
+-------------
+
+- ibm_sv_manage_replication_policy - Enabled support for logging in via partition ip
+- ibm_svc_manage_volume - Added support for autoexpand, preferrednode and cache parameters
+
+New Modules
+-----------
+
+- ibm_sv_manage_clone - This module manages clone and thinclone of volume and volumegroup.
+
 v3.1.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This collection provides a series of Ansible modules and plugins for interacting
 
 ## Requirements
 
-- Ansible version 2.15 or higher
+- Ansible version 2.16 or higher
 - Python 3.10 or higher for controller nodes
 
 ## Installation
@@ -101,6 +101,7 @@ Alternatively, you can add a full namepsace and collection name in the `collecti
 - ibm_svcinfo_command - Runs svcinfo CLI command on Storage Virtualize systems over SSH session
 - ibm_svctask_command - Runs svctask CLI command(s) on Storage Virtualize systems over SSH session
 - ibm_sv_manage_awss3_cloudaccount - Manages Amazon S3 cloud account configuration on Storage Virtualize systems
+- ibm_sv_manage_clone - Manages clone and thinclone of volume and volumegroup
 - ibm_sv_manage_cloud_backup - Manages cloud backups on Storage Virtualize systems
 - ibm_sv_manage_drive - Manages drive state changes, tasks and dump
 - ibm_sv_manage_fc_partnership - Manages Fibre Channel (FC) partnership on Storage Virtualize systems

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -233,3 +233,17 @@ releases:
         name: ibm_sv_manage_system_certificate
         namespace: ''
     release_date: '2025-10-08'
+  3.2.0:
+    changes:
+      minor_changes:
+        - ibm_svc_manage_volume - Added support for autoexpand, preferrednode and cache parameters
+        - ibm_sv_manage_replication_policy - Enabled support for logging in via partition ip
+      release_summary: Added support for looging in using the partition IP address across volume,
+        volumegroup, host, hostcluster, snapshot, replication, and GAM modules, modified
+        partition_migration_host_actions playbook for iSCSI hosts and added support for volume
+        parameters autoexpand, preferrednode and cache.
+    modules:
+      - description: This module manages clone and thinclone of volume and volumegroup.
+        name: ibm_sv_manage_clone
+        namespace: ''
+    release_date: '2026-01-14'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: ibm
 name: storage_virtualize
-version: 3.1.0
+version: 3.2.0
 readme: README.md
 authors:
   - Sumit Kumar Gupta (github.com/sumitguptaibm)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.15.0'
+requires_ansible: '>=2.16.0'

--- a/playbooks/partition_migration_host_actions/README.md
+++ b/playbooks/partition_migration_host_actions/README.md
@@ -4,159 +4,282 @@
 
 - [Objective](#objective)
 - [Prerequisites](#prerequisites)
-- [Playbooks Overview](#playbook-overview)
+- [Playbooks](#playbooks)
+- [Configuration](#configuration)
+  - [Inventory](#inventory)
+  - [Variables](#variables)
+- [How It Works](#how-it-works)
 - [Ansible Logging](#ansible-logging)
-- [Adding support for new operating system](#adding-support-for-new-operating-system)
+- [Extending to New Operating Systems](#extending-to-new-operating-systems)
 - [Authors](#authors)
+
 
 ## Objective
 
-This Ansible playbook suite automates host-side actions for migrating storage partitions from one IBM FlashSystem to another.
+This Ansible playbook suite automates **host-side actions** required while migrating storage partitions from one IBM FlashSystem to another.
+It continuously monitors partition migration events on the FlashSystems and performs the appropriate actions on mapped hosts (Linux / Windows) to ensure paths are properly discovered, rescan, and validated before commit or rollback.
 
 ## Prerequisites
 
-- Controller Requirements:
-  - IBM Storage Virtualize ansible collection plugins v2.7.4 or above must be installed.
-  - The Ansible controller machine must have Python 3.10 or higher.
+### Controller Requirements
 
-- Target Host Requirements:
-  - All remote hosts must have Python 3.8 or higher.
-  - Windows Hosts:
-    - Must have either `sshpass` or the `winRM` utility installed.
-    - SSH must be set up between the Windows host and the Ansible controller.
-    - Playbooks use PowerShell commands, which require Administrator privileges.
-  - Linux Hosts:
-    - Must have `rescan-scsi-bus.sh` (`scsitools`)
-    - Multipath utilities installed and configured.
-    - Playbooks use rescan-scsi-bus.sh, which requires root privileges.
+- IBM Storage Virtualize Ansible Collection plugins **v2.7.4 or above** must be installed.
+- The Ansible controller machine must have **Python 3.10+**.
 
-## Playbook Overview
+### Target Host Requirements
 
-These playbooks monitor and respond to partition migration events by performing appropriate host actions (it fixes the supported events).
+#### Common
+
+- All remote hosts must have **Python 3.8+**.
+- Ensure:
+  - **Zoning** is present between the host and the **target FlashSystem** (for FC).
+  - **IP connectivity** is available between the host and the **iSCSI target** (for iSCSI).
+
+#### Windows Hosts
+
+- Must have either:
+  - `sshpass`, or  
+  - `winRM` utility installed.
+- SSH access must be set up between the Windows host and the Ansible controller.
+- Playbooks use **PowerShell** and require **Administrator** privileges.
+- **Microsoft iSCSI Initiator Service** must be installed and running.
+
+#### Linux Hosts
+
+- `rescan-scsi-bus.sh` (package `scsitools`) installed.
+- Multipath utilities (e.g. `multipath`, `multipathd`) installed and configured.
+- Playbooks use `rescan-scsi-bus.sh`, which requires **root** privileges.
+- `iscsiadm` installed and available in `PATH`.
+
+### FlashSystem Requirements
+
+- **iSCSI**
+  - Host-type **portset** must be configured with data IPs.
+  - The user can either:
+    - Provide specific IPs in `inventory.ini`, or
+    - Let the playbook perform discovery/login on **all IPs** present in the portset.
+- **FC**
+  - No specific requirement other than correct **zoning**.
 
 > [!NOTE]
-> The script uses `rescan-scsi-bus.sh`, which may impact I/O for other volumes mapped to the same host. Supported Events are,
->  - `host_rescan_requested`
->  - `commit_or_rollback`
+> - The playbooks **do not** create portsets or assign IPs to portsets.
+> - The same framework supports hosts using **FC**, **iSCSI**, or **both**.
 
-### 1. main.yml
-  - The primary playbook to be executed:
-    ```ansible-playbook main.yml -i inventory.ini```
+## Playbooks
 
-  - Functionality:
-    - Continuously looks for active partition migrations.
-    - Based on the detected event, it triggers the required playbooks for fixing that particular event.
-    - Supports only Linux and Windows hosts by default, with a provision to extend to other Operating Systems types.
+The main files in this directory are:
 
-  - Workflow:
-    - Detects migration events and identifies corresponding hosts using `host_identification.yml`.
-    - On `host_rescan_requested`:
-      - Triggers `rescan_multiple_devices.yml` to rescan devices on the identified hosts.
-      - Retries up to 5 times if rescan fails.
-    - On `commit_or_rollback`:
-      - Triggers `verify_multiple_devices.yml` to validate path count.
-      - Compares active paths per node with `min_active_path` set by the user.
+- `main.yml`  
+  Entry-point playbook. Monitors partition migrations and orchestrates all other playbooks.
+  Usage: ```ansible-playbook main.yml -i inventory.ini```
 
-  - `commit_or_rollback` event will be skipped in case any of the following condition are met or set by user:
-    - Deployment type set to 1 (localhost) by user, with multiple hosts mapped to the partition.
-    - Number of detected hosts on FlashSystem doesn't match the inventory.
-    - Partition includes hosts with unsupported operating system.
-    - No host is mapped to the migrating partition.
+- `inventory.ini`  
+  Defines:
+  - `application_server` (or other host groups): hosts mapped to FlashSystems
+  - `flash_systems`: FlashSystems to monitor for migration events
 
+- `vars.yml`  
+  User-tunable parameters controlling behavior (min paths, deployment type, inventory path, log path, etc.).
 
-### 2. inventory.ini
-Defines hosts and FlashSystems with their access credentials.
-  - application_server: List of host mapped to flashsystems
-  - flash_systems: List of FlashSystems that the user wants to monitor for migration
-    ```
-    [application_server]
-    linux1 ansible_host=x.x.x.x ansible_user=root ansible_ssh_pass=password ansible_connection=ssh
-    windows1 ansible_host=x.x.x.x ansible_user=Administrator ansible_ssh_pass=password ansible_connection=ssh ansible_shell_type=cmd
+- `host_identification.yml`  
+  Identifies hosts mapped to a migrating partition, and determines OS (Linux / Windows / others).
 
-    [flash_systems]
-    fs1 ansible_host=x.x.x.x ansible_user=superuser ansible_password=password
-    fs2 ansible_host=x.x.x.x ansible_user=superuser ansible_password=password
-    ```
+- `discover_multipath_devices.yml`  
+  Performs device and multipath discovery (e.g. iSCSI login, SCSI rescan, multipath detection) on target hosts.
 
-### 3. vars.yml
-Holds user-defined parameters for customizing the playbook behavior.
+- `rescan_multipath_devices.yml`  
+  Handles `host_rescan_requested` events by rescanning devices and refreshing multipath information on mapped hosts.
 
-  | Parameter            | Description                                                                           |
-  | -------------------- | ------------------------------------------------------------------------------------- |
-  | `min_active_path`    | Minimum required paths from node to host. Use `0` to skip commit validation           |
-  | `hosts_name`         | Host group name from `inventory.ini` (e.g., `application_server` or `localhost`)      |
-  | `deployment_type`    | `1`: Localhost; `2`: Ansible Tower                                                    |
-  | `io_stability_time`  | Wait time to ensure I/O stability                                                     |
-  | `inventory_file`     | Path to the inventory file                                                            |
-  | `logpath`            | Path to store log files                                                               |
-  | `temp_file_location` | Temporary files location during script execution                                      |
+- `verify_multipath_devices.yml`  
+  For `commit_or_rollback` events, verifies active path counts per device and per node, and checks compliance with `min_active_path`.  
+  > Currently supports **Linux** only.
+
+- `iscsi_logout.yml`  
+  Handles iSCSI logout actions for appropriate scenarios (e.g. cleanup after migration / rollback).
+
+- `test_and_rescan_hosts.yml`  
+  Helper playbook to test connectivity and perform host-side rescans where needed.
+
+## Configuration
+
+### Inventory
+
+`inventory.ini` defines the hosts and FlashSystems with their access credentials.
+
+#### Example – FC
+
+```
+[application_server]
+linux1 ansible_host=x.x.x.x ansible_user=root ansible_ssh_pass=password ansible_connection=ssh
+windows1 ansible_host=x.x.x.x ansible_user=Administrator ansible_ssh_pass=password ansible_connection=ssh ansible_shell_type=cmd
+
+[flash_systems]
+fs1 ansible_host=x.x.x.x ansible_user=superuser ansible_password=password
+fs2 ansible_host=x.x.x.x ansible_user=superuser ansible_password=password
+```
+
+#### Example – iSCSI
+```
+[application_server]
+win1   ansible_host=x.x.x.x ansible_user=admin ansible_ssh_pass=password ansible_connection=ssh ansible_shell_type=cmd ansible_iscsi_ips='["x.x.x.x","x.x.x.x"]'
+linux1 ansible_host=x.x.x.x ansible_user=root  ansible_ssh_pass=password ansible_connection=ssh ansible_iscsi_ips='["x.x.x.x","x.x.x.x"]'
+linux2 ansible_host=x.x.x.x ansible_user=root  ansible_ssh_pass=password ansible_connection=ssh
+
+[flash_systems]
+fs1 ansible_host=x.x.x.x ansible_user=superuser ansible_password=password
+fs2 ansible_host=x.x.x.x ansible_user=superuser ansible_password=password
+```
+
+### Variables
+
+All user-configurable parameters are defined in vars.yml:
+| Parameter            | Description                                                                                             |
+| -------------------- | --------------------------------------------------------------------------------------------------------|
+| `min_active_path`    | Minimum required active paths per node-to-host for all devices. Use 0 to skip auto commit of migration. |
+| `hosts_name`         | Host group name from `inventory.ini` (e.g., `application_server` or `localhost`)                        |
+| `deployment_type`    | `1`: Localhost; `2`: Ansible Tower  (or other central controller).                                      |
+| `io_stability_time`  | Wait time (in seconds) to ensure I/O stability before validation/commit.                                |
+| `inventory_file`     | Path to the inventory file (e.g. inventory.ini).                                                        |
+| `logpath`            | Path to store log files (update logrotate configuration if using a custom directory).                   |
+| `temp_file_location` | Directory to store temporary files during script execution.                                             |
+  
+  
+## How It Works
+
+These playbooks monitor partition migration status on FlashSystems and trigger host-side actions to keep paths consistent and compliant.
+
+>[!NOTE]
+>The framework supports at least the following migration events:
+> - `host_rescan_requested`
+> - `commit_or_rollback`
+
+>[!WARNING]
+>The solution uses rescan-scsi-bus.sh on Linux.
+>This can impact I/O for other volumes mapped to the same host.
+>Carefully choose when to run the playbook (e.g. outside critical peak load).
+
+### Event Handling Workflow
+
+Monitoring / Dispatch (main.yml)-
+Continuously queries FlashSystems for active partition migrations.
+Identifies migration events and mapped hosts using host_identification.yml.
+For each event, dispatches the appropriate helper playbook.
+
+host_rescan_requested-
+Triggers rescan_multipath_devices.yml on the identified hosts.
+Performs device / SCSI rescan and multipath refresh.
+Retries up to 5 times if rescan validation fails (configurable via vars if required).
+
+commit_or_rollback-
+Triggers verify_multipath_devices.yml on Linux hosts.
+Verifies path counts per device, per node.
+Compares results against min_active_path configured in vars.yml.
+If all devices are compliant and min_active_path > 0:
+The playbook can auto-commit the migration on FlashSystem.
+
+If validation fails:
+The partition migration is not auto-committed, and details are logged for manual inspection.
+Skip Conditions for commit_or_rollback
+The commit_or_rollback event will be skipped if any of the following is true:
+Deployment type is set to 1 (localhost) but the partition has multiple hosts mapped.
+The number of detected hosts on FlashSystem does not match the hosts defined in the inventory.
+The partition includes hosts with unsupported operating systems.
+No host is mapped to the migrating partition.
+
+>[!NOTE]
+>By default, auto-commit is disabled by setting min_active_path = 0.
+>Fixing commit_or_rollback events and auto-committing will delete the partition from the source copy.
+
+Monitor:
+Ansible output for event handling and decisions.
+Logs written to the configured logpath (if any).
 
 ## Ansible Logging
-
-To enable logging, export the following environment variables:
+To enable Ansible logging, set the following environment variable on the controller:
 ```
 export ANSIBLE_LOG_PATH=/var/log/ansible.log
 ```
+You can customize the path if needed; ensure the directory exists and has appropriate permissions.
 
-## Adding support for new operating system:
+## Extending to New Operating Systems
+To support additional operating systems, add OS-specific blocks to the following playbooks:
+- host_identification.yml
+  - Currently supports Linux and Windows.
+  - For a new OS, ensure it can be identified (e.g. via facts or custom conditions).
+  - Provide host identifiers in the desired format, for example:
 
-To add support for new operating system, user need to do add block in following files similar to Linux and Windows block:
-  - host_identification.yml
-    - Currently, the playbook supports only Linux and Windows.
-    - To add support for new operating system User needs to provide FC WWPNs in following format:
-      ```
-          fc_host_wwpns_upper: [
-            "10000090FAA0B824",
-            "10000090FAA0B825"
-          ]
-      ```
+    FC Example
+    ```
+    fc_host_wwpns_upper: [
+      "10000090FAA0B824",
+      "10000090FAA0B825"
+    ]
+    ```
 
-  - rescan_multiple_devices.yml
-    - Currently, the playbook supports only Linux and Windows hosts.
-    - User needs to provide rescan CLI path or rescan method for the specific operating system that user wants to add
+    iSCSI Example
+    ```
+    iscsi_ips: [
+      "10.10.10.14",
+      "10.10.10.15",
+      "10.10.10.16",
+      "10.10.10.17"
+    ]
+    iscsi_name: [
+      "iqn.1994-05.com.redhat:529611838e5d"
+    ]
+    ```
 
-  - verify_multipath_devices.yml
-    - Currently, the playbook supports only Linux.
-    - To add support for new operating system User need to provide output to process in following format:
-      ```
+- rescan_multipath_devices.yml
+  - Currently supports Linux and Windows.
+  - For new OS types, provide:
+    - Rescan CLI path, or
+    - The rescan method/commands required for that OS.
+
+- verify_multipath_devices.yml
+  - Currently supports Linux.
+  - For a new OS, ensure the script produces (or can convert to) output in the following format:
+
+    ```
+    {
+      "data": [
         {
-          "data": [
-              {
-                  "active_paths_on_tgt": {
-                      "dm-0": {
-                          "node1": {
-                              "active_no_paths": 2,
-                              "inactive_no_paths": 0
-                          },
-                          "node2": {
-                              "active_no_paths": 2,
-                              "inactive_no_paths": 0
-                          },
-                          "uuid": "(36005076810da8186b80000000000006e)"
-                      },
-                      "dm-1": {
-                          "node1": {
-                              "active_no_paths": 2,
-                              "inactive_no_paths": 0
-                          },
-                          "node2": {
-                              "active_no_paths": 2,
-                              "inactive_no_paths": 0
-                          },
-                          "uuid": "(36005076810da8186b80000000000006f)"
-                      },
-                      "inventory_name": "linux1"
-                  },
-                  "non_compliant_devices": []
-              }
-          ]
+          "active_paths_on_tgt": {
+            "dm-0": {
+              "node1": {
+                "active_no_paths": 2,
+                "inactive_no_paths": 0
+              },
+              "node2": {
+                "active_no_paths": 2,
+                "inactive_no_paths": 0
+              },
+              "uuid": "(36005076810da8186b80000000000006e)"
+            },
+            "dm-1": {
+              "node1": {
+                "active_no_paths": 2,
+                "inactive_no_paths": 0
+              },
+              "node2": {
+                "active_no_paths": 2,
+                "inactive_no_paths": 0
+              },
+              "uuid": "(36005076810da8186b80000000000006f)"
+            },
+            "inventory_name": "linux1"
+          },
+          "non_compliant_devices": []
         }
-      ```
+      ]
+    }
+    ```
+    The verification logic expects this structure when evaluating compliance with min_active_path.
 
 ## Authors
 
 - Prateek Mandge (prateekmandge@ibm.com)
 - Mohit Chitlange (mochitla@in.ibm.com)
+- Ashwin Joshi (ashjosh1@in.ibm.com)
 - Chetan Borkar (chetan.borkar@ibm.com)
 - Sumit Kumar Gupta (sumit.gupta16@ibm.com)
 - Aditya Bhosale (adityabhosale@ibm.com)

--- a/playbooks/partition_migration_host_actions/discover_multipath_devices.yml
+++ b/playbooks/partition_migration_host_actions/discover_multipath_devices.yml
@@ -1,0 +1,333 @@
+- name: Load VMD Output from File on Localhost
+  hosts: localhost
+  gather_facts: false
+  tasks:
+
+
+    - name: Read data provided by host_identification.yml playbook from file.
+      ansible.builtin.slurp:
+        src: "{{ file_name }}/matched_hosts.json"
+      register: vmd_host_matched_list
+
+    - name: Parse Output to read content.
+      ansible.builtin.set_fact:
+        host_matched_list_processed: "{{ vmd_host_matched_list['content'] | b64decode | from_json }}"
+
+    - name: Extract FC inventory hostnames
+      ansible.builtin.set_fact:
+        vmd_host_matched_list_processed: >-
+          {{
+            host_matched_list_processed
+            | selectattr('connection', 'equalto', 'iscsi')
+            | map(attribute='inventory_hostname')
+            | list
+          }}
+
+    - name: Mapping between inventory_hostname and iscsi_ips for iSCSI connections only
+      ansible.builtin.set_fact:
+        inv_iscsi_ip_map: >-
+          {{
+            dict(
+              host_matched_list_processed
+              | selectattr('connection', 'equalto', 'iscsi')
+              | map(attribute='inventory_hostname')
+              | zip(
+                  host_matched_list_processed
+                  | selectattr('connection', 'equalto', 'iscsi')
+                  | map(attribute='iscsi_ips')
+                )
+            )
+          }}
+
+- name: Rescan and verify SCSI devices and multipath
+  hosts: "{{ hostvars['localhost'].vmd_host_matched_list_processed | default([]) }}"
+  serial: 1
+  tasks:
+
+    - name: Gather facts for all hosts.
+      ansible.builtin.setup:
+      register: system_info
+
+    # Linux-specific (RHEL) tasks
+    - name: Linux tasks
+      when: system_info.ansible_facts.ansible_system == "Linux"
+      block:
+
+        - name: When ips are provide in inventory file for linux
+          when:
+            - hostvars[inventory_hostname] is defined
+            - "'ansible_iscsi_ips' in hostvars[inventory_hostname]"
+            - hostvars[inventory_hostname].ansible_iscsi_ips | length > 0
+          block:
+
+            - name: Discover and login iSCSI targets from inventory file
+              ansible.builtin.shell: |
+                iscsiadm -m discovery -t st -p "{{ item }}" -l
+              register: iscsi_results
+              changed_when: false
+              # failed_when: iscsi_results.rc != 0
+              ignore_errors: true
+              loop: "{{ hostvars[inventory_hostname].ansible_iscsi_ips }}"
+              loop_control:
+                label: "{{ item }}"
+
+            - name: Show iSCSI discovery results for inventory file entries
+              ansible.builtin.debug:
+                msg: |
+                  RC: {{ item.rc }}
+              loop: "{{ iscsi_results.results }}"
+
+            - name: Relogin iSCSI session for inventory file
+              when: rescan_flag == "yes"
+              block:
+                - name: Relogin iSCSI session if it's not active
+                  ansible.builtin.shell: |
+                    echo "Relogin: {{ item }}"
+                    output=$(iscsiadm -m node -p {{ item }} -R 2>&1)
+                    rc=$?
+                    if [[ "$output" == *"No session found."* || $rc -ne 0 ]]; then
+                      echo "No session found. Attempting discovery and login..."
+                      iscsiadm -m discovery -t st -p {{ item }}
+                      if iscsiadm -m discovery -t st -p {{ item }} -l; then
+                        echo "Login successful for {{ item }}."
+                      else
+                          echo "Login failed for {{ item }}."
+                          exit 1
+                      fi
+                    else
+                        echo "Relogin successful for {{ item }}."
+                    fi
+                  register: relogin_result
+                  loop: "{{ hostvars[inventory_hostname].ansible_iscsi_ips }}"
+                  loop_control:
+                    label: "{{ item }}"
+                  changed_when: false
+                  ignore_errors: true
+
+                - name: Show iSCSI discovery results
+                  ansible.builtin.debug:
+                    msg: |
+                      RC: {{ item.rc }}
+                  loop: "{{ relogin_result.results }}"
+
+
+        - name: When ips are fetch from portset for linux
+          when: "'ansible_iscsi_ips' not in hostvars[inventory_hostname] or hostvars[inventory_hostname].ansible_iscsi_ips == []"
+          block:
+
+            - name: Set_fact for iscsi_ip
+              ansible.builtin.set_fact:
+                iscsi_ip_list: "{{ hostvars['localhost'].inv_iscsi_ip_map[inventory_hostname] }}"
+
+            - name: Discover and login iSCSI targets
+              ansible.builtin.shell: |
+                iscsiadm -m discovery -t st -p "{{ item }}" -l
+              register: iscsi_results
+              changed_when: false
+              # failed_when: iscsi_results.rc != 0
+              ignore_errors: true
+              loop: "{{ iscsi_ip_list }}"
+              loop_control:
+                label: "{{ item }}"
+
+            - name: Show iSCSI discovery results
+              ansible.builtin.debug:
+                msg: |
+                  RC: {{ item.rc }}
+              loop: "{{ iscsi_results.results }}"
+
+            - name: Relogin iSCSI session
+              when: rescan_flag == "yes"
+              block:
+                - name: Relogin iSCSI session if it's not active
+                  ansible.builtin.shell: |
+                    echo "Relogin: {{ item }}"
+                    output=$(iscsiadm -m node -p {{ item }} -R 2>&1)
+                    rc=$?
+                    if [[ "$output" == *"No session found."* || $rc -ne 0 ]]; then
+                      echo "No session found. Attempting discovery and login..."
+                      iscsiadm -m discovery -t st -p {{ item }}
+                      if iscsiadm -m discovery -t st -p {{ item }} -l; then
+                        echo "Login successful for {{ item }}."
+                      else
+                          echo "Login failed for {{ item }}."
+                          exit 1
+                      fi
+                    else
+                        echo "Relogin successful for {{ item }}."
+                    fi
+                  register: relogin_result
+                  loop: "{{ iscsi_ip_list }}"
+                  loop_control:
+                    label: "{{ item }}"
+                  changed_when: false
+                  ignore_errors: true
+
+                - name: Show iSCSI discovery results
+                  ansible.builtin.debug:
+                    msg: |
+                      RC: {{ item.rc }}
+                  loop: "{{ relogin_result.results }}"
+
+
+    # Windows
+    - name: Windows tasks
+      when: system_info.ansible_facts.ansible_system == "Win32NT"
+      block:
+
+        - name: When IPs are provided in inventory file for Windows
+          when:
+            - hostvars[inventory_hostname] is defined
+            - "'ansible_iscsi_ips' in hostvars[inventory_hostname]"
+            - hostvars[inventory_hostname].ansible_iscsi_ips | length > 0
+          block:
+
+            - name: Ensure iSCSI Initiator Service is running
+              ansible.windows.win_service:
+                name: MSiSCSI
+                start_mode: auto
+                state: started
+
+            - name: Add iSCSI Target Portals   # noqa: ignore-errors
+              ansible.windows.win_shell: |
+                New-IscsiTargetPortal -TargetPortalAddress {{ item }} -ErrorAction SilentlyContinue
+              loop: "{{ hostvars[inventory_hostname].ansible_iscsi_ips }}"
+              loop_control:
+                label: "{{ item }}"
+              ignore_errors: true
+
+            - name: Discover and login iSCSI targets  # noqa: ignore-errors
+              ansible.windows.win_shell: |
+                $targets = Get-IscsiTarget | Where-Object { $_.IsConnected -eq $false }
+                foreach ($target in $targets) {
+                  Connect-IscsiTarget -NodeAddress $target.NodeAddress -IsPersistent $true -IsMultipathEnabled $true
+                }
+              register: iscsi_results
+              changed_when: false
+              ignore_errors: true
+
+            - name: Show iSCSI discovery results
+              ansible.builtin.debug:
+                msg: |
+                  RC: {{ iscsi_results.rc }}
+                  Stdout: {{ iscsi_results.stdout }}
+                  Stderr: {{ iscsi_results.stderr }}
+
+            - name: Relogin iSCSI session if not active
+              when: rescan_flag is defined and rescan_flag | lower == 'yes'
+              block:
+
+                - name: Check and relogin iSCSI targets
+                  ansible.windows.win_shell: |
+                    $ipList = "{{ hostvars[inventory_hostname].ansible_iscsi_ips | join(',') }}"
+                    foreach ($ip in $ipList -split ',') {
+                      $portal = $ip.Trim()
+                      $targets = Get-IscsiTarget | Where-Object { $_.IsConnected -eq $false }
+                      if ($targets.Count -gt 0) {
+                        Write-Host "Relogin: $portal"
+                        foreach ($target in $targets) {
+                          try {
+                            Connect-IscsiTarget -NodeAddress $target.NodeAddress -IsPersistent $true -IsMultipathEnabled $true
+                            Write-Host "Login successful for $($target.NodeAddress)"
+                          } catch {
+                            Write-Host "Login failed for $($target.NodeAddress)"
+                          }
+                        }
+                      } else {
+                        Write-Host "All sessions already connected."
+                      }
+                    }
+                  register: relogin_result
+                  changed_when: false
+                  ignore_errors: true
+
+                - name: Show iSCSI relogin results
+                  ansible.builtin.debug:
+                    msg: |
+                      RC: {{ relogin_result.rc }}
+                      Stdout: {{ relogin_result.stdout }}
+                      Stderr: {{ relogin_result.stderr }}
+
+
+        - name: When ips are fetch from portset for Windows
+          when: "'ansible_iscsi_ips' not in hostvars[inventory_hostname] or hostvars[inventory_hostname].ansible_iscsi_ips == []"
+          block:
+
+            - name: Set_fact for iscsi_ip
+              ansible.builtin.set_fact:
+                iscsi_ip_list: "{{ hostvars['localhost'].inv_iscsi_ip_map[inventory_hostname] }}"
+
+            - name: Ensure iSCSI Initiator Service is running
+              ansible.windows.win_service:
+                name: MSiSCSI
+                start_mode: auto
+                state: started
+
+            - name: Add iSCSI Target Portals  # noqa: ignore-errors
+              ansible.windows.win_shell: |
+                New-IscsiTargetPortal -TargetPortalAddress {{ item }} -ErrorAction SilentlyContinue
+              loop: "{{ iscsi_ip_list }}"
+              loop_control:
+                label: "{{ item }}"
+              ignore_errors: true
+
+            - name: Discover and login iSCSI targets  # noqa: ignore-errors
+              ansible.windows.win_shell: |
+                $targets = Get-IscsiTarget | Where-Object { $_.IsConnected -eq $false }
+                foreach ($target in $targets) {
+                  Connect-IscsiTarget -NodeAddress $target.NodeAddress -IsPersistent $true -IsMultipathEnabled $true
+                }
+              register: iscsi_results
+              changed_when: false
+              ignore_errors: true
+
+            - name: Show iSCSI discovery results
+              ansible.builtin.debug:
+                msg: |
+                  RC: {{ iscsi_results.rc }}
+                  Stdout: {{ iscsi_results.stdout }}
+                  Stderr: {{ iscsi_results.stderr }}
+
+            - name: Relogin iSCSI session if not active
+              when: rescan_flag is defined and rescan_flag | lower == 'yes'
+              block:
+
+                - name: Check and relogin iSCSI targets
+                  ansible.windows.win_shell: |
+                    $ipList = "{{ iscsi_ip_list | join(',') }}"
+                    foreach ($ip in $ipList -split ',') {
+                      $portal = $ip.Trim()
+                      $targets = Get-IscsiTarget | Where-Object { $_.IsConnected -eq $false }
+                      if ($targets.Count -gt 0) {
+                        Write-Host "Relogin: $portal"
+                        foreach ($target in $targets) {
+                          try {
+                            Connect-IscsiTarget -NodeAddress $target.NodeAddress -IsPersistent $true -IsMultipathEnabled $true
+                            Write-Host "Login successful for $($target.NodeAddress)"
+                          } catch {
+                            Write-Host "Login failed for $($target.NodeAddress)"
+                          }
+                        }
+                      } else {
+                        Write-Host "All sessions already connected."
+                      }
+                    }
+                  register: relogin_result
+                  changed_when: false
+                  ignore_errors: true
+
+                - name: Show iSCSI relogin results
+                  ansible.builtin.debug:
+                    msg: |
+                      RC: {{ relogin_result.rc }}
+                      Stdout: {{ relogin_result.stdout }}
+                      Stderr: {{ relogin_result.stderr }}
+
+
+    - name: Other OS tasks
+      when: system_info.ansible_facts.ansible_system == "Other OS"
+      block:
+        - name: Define task
+          ansible.builtin.debug:
+            msg: Write your code block here
+          # Please add OS specific tasks to rescan multipath, refer to following blocks

--- a/playbooks/partition_migration_host_actions/host_identification.yml
+++ b/playbooks/partition_migration_host_actions/host_identification.yml
@@ -1,5 +1,5 @@
 ---
-- name: Map flashsystems host with inventory hostnames
+- name: Map flashsystem host with inventory hostname
   vars_files:
     - vars.yml
   hosts: "{{hosts_name}}"
@@ -19,18 +19,27 @@
       when: system_info.ansible_facts.ansible_system == "Linux"
       block:
 
-        - name: Read FC WWPNs from host.
-          ansible.builtin.shell: cat /sys/class/fc_host/host*/port_name  # Replace with actual file path on remote hosts
-          register: fc_host_wwpns_output
-          changed_when: false
+        - name: Check if FC directory exists
+          ansible.builtin.stat:
+            path: /sys/class/fc_host
+          register: fc_host_dir
 
-        - name: Normalize FC WWPNs to uppercase.
-          ansible.builtin.set_fact:
-            fc_host_wwpns_upper: "{{ fc_host_wwpns_output.stdout_lines | map('upper') | list }}"
+        - name: Fetching WWPNs data
+          when: fc_host_dir.stat.exists
+          block:
 
-        - name: Remove the 0x prefix from the list.
-          ansible.builtin.set_fact:
-            fc_host_wwpns_upper_clean: "{{ fc_host_wwpns_upper | map('regex_replace', '^0X', '') | list }}"
+            - name: Read FC WWPNs from host.
+              ansible.builtin.shell: cat /sys/class/fc_host/host*/port_name
+              register: fc_host_wwpns_output
+              changed_when: false
+
+            - name: Normalize FC WWPNs to uppercase.
+              ansible.builtin.set_fact:
+                fc_host_wwpns_upper: "{{ fc_host_wwpns_output.stdout_lines | map('upper') | list }}"
+
+            - name: Remove the 0x prefix from the list.
+              ansible.builtin.set_fact:
+                fc_host_wwpns_upper_clean: "{{ fc_host_wwpns_upper | map('regex_replace', '^0X', '') | list }}"
 
         - name: Extract FC WWPNs.
           ansible.builtin.set_fact:
@@ -39,6 +48,32 @@
         - name: Print WWPN.
           ansible.builtin.debug:
             var: fc_host_wwpns
+
+        - name: Initialize iscsi_host_iqn_output_list
+          ansible.builtin.set_fact:
+            iscsi_host_iqn_output_list: []
+
+        - name: Check if FC directory exists
+          ansible.builtin.stat:
+            path: /etc/iscsi/initiatorname.iscsi
+          register: iscsi_host_dir
+
+        - name: Fetching WWPNs data
+          when: iscsi_host_dir.stat.exists
+          block:
+
+            - name: Read FC WWPNs from host.       # noqa: risky-shell-pipe
+              ansible.builtin.shell: grep '^InitiatorName=' /etc/iscsi/initiatorname.iscsi | cut -d= -f2
+              register: iscsi_host_iqn_output
+              changed_when: false
+
+            - name: Convert to list.
+              ansible.builtin.set_fact:
+                iscsi_host_iqn_output_list: ["{{ iscsi_host_iqn_output.stdout }}"]
+
+            - name: Print iqn.
+              ansible.builtin.debug:
+                var: iscsi_host_iqn_output_list
 
 
     - name: Windows tasks
@@ -64,6 +99,20 @@
         - name: Print WWPN
           ansible.builtin.debug:
             var: fc_host_wwpns
+
+        - name: Read FC iqn from Windows host.
+          ansible.windows.win_shell: |
+            (Get-WmiObject -Namespace root\wmi -Class MSiSCSIInitiator_MethodClass).iSCSINodeName
+          register: iscsi_host_iqn_output
+          changed_when: false
+
+        - name: Rename it
+          ansible.builtin.set_fact:
+            iscsi_host_iqn_output_list: "{{ iscsi_host_iqn_output.stdout_lines }}"
+
+        - name: Print iqn.
+          ansible.builtin.debug:
+            var: iscsi_host_iqn_output_list
 
     - name: Esxi tasks
       when: system_info.ansible_facts.ansible_system == "VMkernel"
@@ -93,6 +142,29 @@
           ansible.builtin.debug:
             var: fc_host_wwpns
 
+        - name: Get iSCSI adapter name    # noqa: risky-shell-pipe
+          ansible.builtin.shell: |
+            esxcli iscsi adapter list | awk '$1 ~ /^[-]+$/ { next } NR > 1 { print $1 }'
+          register: iscsi_adapter_output
+          changed_when: false
+
+        - name: Store iSCSI adapter in a variable
+          ansible.builtin.set_fact:
+            iscsi_adapter: "{{ iscsi_adapter_output.stdout }}"
+
+        - name: Read FC iqn from esxi host.    # noqa: risky-shell-pipe
+          ansible.builtin.shell: |
+            esxcli iscsi adapter get -A "{{ iscsi_adapter }}" | grep "^   Name:" | sed 's/^   Name: //'
+          register: iscsi_host_iqn_output
+          changed_when: false
+
+        - name: Rename it
+          ansible.builtin.set_fact:
+            iscsi_host_iqn_output_list: "{{ iscsi_host_iqn_output.stdout_lines }}"
+
+        - name: Print iqn.
+          ansible.builtin.debug:
+            var: iscsi_host_iqn_output_list
 
 - name: Load Output from File on Localhost
   hosts: localhost
@@ -100,9 +172,9 @@
   serial: 1
   tasks:
 
-    - name: Read data povided by Main.yml playbook from file.
+    - name: Read data provided by main.yml playbook from file.
       ansible.builtin.slurp:
-        src: "{{ file_name }}/svc_host_obj_list_present.json"  # Replace with actual path on localhost
+        src: "{{ file_name }}/{{ json_file }}"
       register: vmd_output_file
 
     - name: Parse Output to read content.
@@ -113,7 +185,7 @@
 - name: Match and Store Host Details
   vars_files:
     - vars.yml
-  hosts: "{{hosts_name}}"
+  hosts: "{{ hosts_name }}"
   gather_facts: false
   serial: 1
   tasks:
@@ -127,34 +199,76 @@
       ansible.builtin.set_fact:
         matched_hosts: []
 
-    - name: Map inventory_hostname with flash_systems host name based on WWPN.
+    - name: Initialize an empty list.
+      ansible.builtin.set_fact:
+        matched_inventory_hosts: []
+
+    - name: Map inventory_hostname with flash_systems host name based on WWPN
       ansible.builtin.set_fact:
         matched_hosts: >-
           {{
-            matched_hosts +
-            [{'inventory_hostname': inventory_hostname, 'fs_host_name': item.value.name, 'host_type': system_info.ansible_facts.ansible_system}]
+            matched_hosts + [{
+              'inventory_hostname': inventory_hostname,
+              'fs_host_name': item.value.name,
+              'host_type': system_info.ansible_facts.ansible_system,
+              'connection': item.value.type
+            }]
           }}
       loop: "{{ vmd_output | dict2items }}"
-      when: item.value.wwpns | intersect(fc_host_wwpns) | length > 0
+      when:
+        - item.value is mapping
+        - "'wwpns' in item.value"
+        - "(item.value.wwpns | intersect(fc_host_wwpns) | length) > 0"
+        - item.value.type == 'FC'
+
+    - name: Map inventory_hostname with flash_systems host name based on iqn.
+      ansible.builtin.set_fact:
+        matched_hosts: >-
+          {{
+            matched_hosts + [{
+              'inventory_hostname': inventory_hostname,
+              'iscsi_host_name': item.value.name,
+              'host_type': system_info.ansible_facts.ansible_system,
+              'connection': item.value.type,
+              'iscsi_ips': item.value.iscsi_ips
+              }]
+          }}
+      loop: "{{ vmd_output | dict2items }}"
+      when:
+        - item.value is mapping
+        - "'iscsi_name' in item.value"
+        - "(item.value.iscsi_name | intersect(iscsi_host_iqn_output_list) | length) > 0"
+        - item.value.type == 'iscsi'
+        - iscsi_host_iqn_output_list is defined
 
     - name: Print Filter matched hosts.
       ansible.builtin.debug:
         var: matched_hosts
 
-    # Appanding data in files
+    # Appending data in files
     - name: Append matched hosts to a JSON file if found.
-      when: matched_hosts | length > 0
+      when: matched_hosts != []
       delegate_to: localhost
       block:
 
+        - name: Set file name if location is target
+          ansible.builtin.set_fact:
+            matched_hosts_file: matched_hosts.json
+          when: location_flag == 'target'
+
+        - name: Set file name if location is source
+          ansible.builtin.set_fact:
+            matched_hosts_file: matched_hosts_source.json
+          when: location_flag == 'source'
+
         - name: Check if the file exists
           ansible.builtin.stat:
-            path: "{{ file_name }}/matched_hosts.json"
+            path: "{{ file_name }}/{{ matched_hosts_file }}"
           register: file_stat
 
         - name: Read the current content of the file if it exists.
           ansible.builtin.slurp:
-            src: "{{ file_name }}/matched_hosts.json"
+            src: "{{ file_name }}/{{ matched_hosts_file }}"
           register: current_content
           when: file_stat.stat.exists
           failed_when: false
@@ -176,5 +290,5 @@
         - name: Write the updated data to the file.
           ansible.builtin.copy:
             content: "{{ updated_data | to_nice_json }}"
-            dest: "{{ file_name }}/matched_hosts.json"
+            dest: "{{ file_name }}/{{ matched_hosts_file }}"
             mode: '0644'

--- a/playbooks/partition_migration_host_actions/inventory.ini
+++ b/playbooks/partition_migration_host_actions/inventory.ini
@@ -1,10 +1,9 @@
-
 [application_server]
-linux1 ansible_host=x.x.x.x ansible_user=root ansible_ssh_pass=password ansible_connection=ssh
-win1 ansible_host=x.x.x.x ansible_user=Administrator ansible_ssh_pass=password ansible_connection=ssh ansible_shell_type=cmd
-esxi1 ansible_host=x.x.x.x ansible_user=root ansible_ssh_pass=password ansible_connection=ssh
+win1 ansible_host=x.x.x.x ansible_user=admin ansible_ssh_pass=password ansible_connection=ssh ansible_shell_type=cmd ansible_iscsi_ips='["x.x.x.x","x.x.x.x"]'
+linux1 ansible_host=x.x.x.x ansible_user=root ansible_ssh_pass=password ansible_connection=ssh ansible_iscsi_ips='["x.x.x.x","x.x.x.x"]'
+linux2 ansible_host=x.x.x.x ansible_user=root ansible_ssh_pass=password ansible_connection=ssh
+
 
 [flash_systems]
 fs1 ansible_host=x.x.x.x ansible_user=superuser ansible_password=password 
 fs2 ansible_host=x.x.x.x  ansible_user=superuser ansible_password=password 
-

--- a/playbooks/partition_migration_host_actions/iscsi_logout.yml
+++ b/playbooks/partition_migration_host_actions/iscsi_logout.yml
@@ -1,0 +1,86 @@
+- name: Load VMD Output from File on Localhost
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Read data provided by host_identification.yml playbook from file.
+      ansible.builtin.slurp:
+        src: "{{ file_name }}/matched_hosts_source.json"
+      register: vmd_host_matched_list
+
+    - name: Parse Output to read content.
+      ansible.builtin.set_fact:
+        host_matched_list_processed: "{{ vmd_host_matched_list['content'] | b64decode | from_json }}"
+
+    - name: Extract FC inventory hostname
+      ansible.builtin.set_fact:
+        vmd_host_matched_list_processed: >-
+          {{
+            host_matched_list_processed
+            | selectattr('connection', 'equalto', 'iscsi')
+            | map(attribute='inventory_hostname')
+            | list
+          }}
+
+    - name: Mapping between inventory_hostname and iscsi_ips
+      ansible.builtin.set_fact:
+        inv_iscsi_ip_map: >-
+          {{
+            dict(
+              host_matched_list_processed | map(attribute='inventory_hostname') |
+              zip(host_matched_list_processed | map(attribute='iscsi_ips'))
+            )
+          }}
+
+- name: Rescan and verify SCSI devices and multipath
+  hosts: "{{ hostvars['localhost'].vmd_host_matched_list_processed | default([]) }}"
+  serial: 1
+  tasks:
+
+    - name: Set_fact for iscsi_ip
+      ansible.builtin.set_fact:
+        iscsi_ip_list: "{{ hostvars['localhost'].inv_iscsi_ip_map[inventory_hostname] }}"
+
+    - name: Gather facts for all hosts.
+      ansible.builtin.setup:
+      register: system_info
+
+    # Linux-specific (RHEL) tasks
+    - name: Linux tasks
+      when: system_info.ansible_facts.ansible_system == "Linux"
+      block:
+
+        - name: Logout iSCSI sessions by target IP on linux
+          ansible.builtin.shell: |
+            iscsiadm -m node -p "{{ item }}" -u
+          register: iscsi_results
+          changed_when: false
+          # failed_when: iscsi_results.rc != 0
+          ignore_errors: true
+          loop: "{{ iscsi_ip_list }}"
+          loop_control:
+            label: "{{ item }}"
+
+    # Windows
+    - name: Windows tasks
+      when: system_info.ansible_facts.ansible_system == "Win32NT"
+      block:
+
+        - name: Logout iSCSI sessions by target IP on Windows
+          ansible.windows.win_shell: |
+            $target_ip = "{{ item }}"
+            $sessions = Get-IscsiSession | Where-Object { $_.TargetPortalAddress -eq $target_ip }
+
+            if ($sessions) {
+                foreach ($session in $sessions) {
+                    Disconnect-IscsiTarget -SessionIdentifier $session.SessionIdentifier -Confirm:$false
+                    Write-Host "Logged out from $($session.TargetNodeName) at $target_ip"
+                }
+            } else {
+                Write-Host "No active sessions found for $target_ip"
+            }
+          loop: "{{ iscsi_ip_list }}"
+          loop_control:
+            label: "{{ item }}"
+          register: iscsi_logout_result
+          changed_when: false
+          ignore_errors: true

--- a/playbooks/partition_migration_host_actions/main.yml
+++ b/playbooks/partition_migration_host_actions/main.yml
@@ -7,6 +7,7 @@
     - vars.yml
   vars:
     are_all_hosts_in_inventory: true
+    commit_flag: true
   serial: 1
   tasks:
 
@@ -22,6 +23,7 @@
         command: "lspartition -gui -json"
         log_path: "{{ logpath }}"
       register: partition_info
+      when: "'flash_systems' in group_names"
 
     - name: Clean the lspartition output
       ansible.builtin.set_fact:
@@ -83,9 +85,10 @@
 
         - name: Initialize extracted_hosts list.
           ansible.builtin.set_fact:
-            extracted_hosts: {}
+            extracted_hosts: []
+            extracted_hosts_tmp: []
 
-        - name: Extract relevant host data for the identified partition.
+        - name: Extract relevant fc host data for the identified partition.
           ansible.builtin.set_fact:
             extracted_hosts: >-
               {{
@@ -94,19 +97,107 @@
                     "inventory_hostname": inventory_hostname,
                     "name": item.Host.name,
                     "wwpns": item.Host.nodes | default([]) | map(attribute='WWPN') | list,
-                    "partition": item.Host.partition_name | default("")
+                    "partition": item.Host.partition_name | default(""),
+                    "type": "FC"
                   }
                 })
               }}
           loop: "{{ shared_targetports_output.results }}"
-          when: item.Host is not none and
-                item.Host.nodes is defined and
-                (item.Host.nodes | length) > 0 and
-                item.Host.nodes[0].WWPN is defined
+          when: item.Host is not none and item.Host.nodes[0].WWPN is defined
+
+        - name: Extract relevant iSCSI host data for the identified partition.
+          ansible.builtin.set_fact:
+            extracted_hosts: >-
+              {{
+                extracted_hosts | combine({
+                  item.Host.id | int: {
+                    "inventory_hostname": inventory_hostname,
+                    "name": item.Host.name,
+                    "iscsi_name": item.Host.nodes | default([]) | map(attribute='iscsi_name') | list,
+                    "partition": item.Host.partition_name | default(""),
+                    "portset_name":item.Host.portset_name,
+                    "type": 'iscsi'
+                  }
+                })
+              }}
+          loop: "{{ shared_targetports_output.results }}"
+          when: item.Host is not none and item.Host.nodes[0].iscsi_name is defined
+
+        - name: Gather lsportset information from flashsystem.
+          ibm.storage_virtualize.ibm_svc_info:
+            gather_subset: "portset"
+            clustername: "{{ ansible_host }}"
+            username: "{{ ansible_user }}"
+            password: "{{ ansible_password }}"
+            objectname: "{{ item.value.portset_name }}"
+            log_path: "{{ logpath }}"
+          changed_when: false
+          register: portset_info
+          loop: "{{ extracted_hosts | dict2items }}"
+          when: item.value.type == 'iscsi'
+
+        - name: Build host entries for extracted_hosts
+          ansible.builtin.set_fact:
+            extracted_hosts_tmp: >-
+              {{
+                extracted_hosts_tmp | default([]) + [
+                  {
+                    (item.item.key | string): (
+                      item.item.value | combine(
+                        (
+                          {'replication_portset_link_uid': item.Portset.replication_portset_link_uid}
+                          if item.item.value.type == 'iscsi'
+                          else {}
+                        )
+                      )
+                    )
+                  }
+                ]
+              }}
+          loop: "{{ portset_info.results }}"
+          when: item.item is defined and item.item.value is defined
+
+        - name: Combine extracted_hosts_tmp into a single dict
+          ansible.builtin.set_fact:
+            extracted_hosts: "{{ extracted_hosts_tmp | default([]) | combine }}"
 
         - name: Process extracted host data if not empty.
-          when: extracted_hosts | length > 0
+          when: extracted_hosts != []
           block:
+
+            - name: Gather lsip information from flashsystem.
+              ibm.storage_virtualize.ibm_svcinfo_command:
+                clustername: "{{ ansible_host }}"
+                username: "{{ ansible_user }}"
+                password: "{{ ansible_password }}"
+                command: "lsip -json"
+                log_path: "{{ logpath }}"
+              register: ip_info
+
+            - name: Convert raw ip_info.stdout string to structured data
+              ansible.builtin.set_fact:
+                ip_info_parsed: "{{ ip_info.stdout | from_json }}"
+
+            - name: Add iscsi_ips to extracted_hosts
+              ansible.builtin.set_fact:
+                extracted_hosts: >-
+                  {%- set updated_hosts = {} -%}
+                  {%- for key, host in extracted_hosts.items() -%}
+                    {%- set _host = host.copy() -%}
+                    {%- if 'type' in _host and _host['type'] == 'iscsi' and 'portset_name' in _host -%}
+                      {%- set ips = [] -%}
+                      {%- for ip in ip_info_parsed -%}
+                        {%- if 'portset_name' in ip and
+                                (ip['portset_name'] | string | lower | trim) == (_host['portset_name'] | string | lower | trim) and
+                                'IP_address' in ip -%}
+                          {%- set _ = ips.append(ip['IP_address']) -%}
+                        {%- endif -%}
+                      {%- endfor -%}
+                      {%- set _ = _host.update({'iscsi_ips': ips}) -%}
+                    {%- endif -%}
+                    {%- set _ = updated_hosts.update({ key: _host }) -%}
+                  {%- endfor -%}
+                  {{ updated_hosts }}
 
             - name: Create path to save tmp
               ansible.builtin.set_fact:
@@ -140,10 +231,24 @@
 
             - name: Call Host_identification playbook to fetch list of host mapped to flashsystem.
               ansible.builtin.command:
-                cmd: "ansible-playbook host_identification.yml -i {{ inventory_file }} -e 'file_name={{ file_path }}'"
+                cmd: >
+                  ansible-playbook host_identification.yml
+                  -i {{ inventory_file }}
+                  -e 'file_name={{ file_path }}
+                  json_file=svc_host_obj_list_present.json
+                  location_flag=target'
               changed_when: false
 
-            - name: Read data povided by host_identification.yml playbook from file.
+            - name: Check if file directory exists
+              ansible.builtin.stat:
+                path: "{{ file_path }}/matched_hosts.json"
+              register: matched_host_dir
+
+            - name: End play if condition not met
+              ansible.builtin.meta: end_play
+              when: not matched_host_dir.stat.exists
+
+            - name: Read data provided by host_identification.yml playbook from file.
               ansible.builtin.slurp:
                 src: "{{ file_path }}/matched_hosts.json"
               register: host_matched_list
@@ -161,7 +266,7 @@
                 is_esxi_host: "{{ 'VMkernel' in (host_matched_list_processed | map(attribute='host_type') | list) }}"
                 extracted_hosts_length: "{{ extracted_hosts.keys() | length }}"
 
-            - name: Set signle host flage for migration
+            - name: Set single host flag for migration
               ansible.builtin.set_fact:
                 single_host_present_flag: "{{ (extracted_hosts_length | int == 1 and deployment_type == 'single_host_migre') | bool }}"
 
@@ -173,11 +278,11 @@
                   ansible.builtin.set_fact:
                     inventory_hosts: "{{ groups[hosts_name] | list }}"
 
-                - name: Extract host which are not presrnt in inventory file
+                - name: Extract host which are not present in inventory file
                   ansible.builtin.set_fact:
                     host_not_in_inventory: "{{ host_matched_inventory_hosts | intersect(inventory_hosts) }}"
 
-                - name: Extract length of host which are not presrnt in inventory file
+                - name: Extract length of host which are not present in inventory file
                   ansible.builtin.set_fact:
                     host_not_in_inventory_length: "{{ host_not_in_inventory | length }}"
 
@@ -199,21 +304,35 @@
       block:
 
         - name: Check extracted_hosts is empty.
-          when: extracted_hosts | length > 0
+          when: extracted_hosts != []
           block:
+
+            - name: Extract FC inventory hostname
+              ansible.builtin.set_fact:
+                fc_hosts: "{{ host_matched_list_processed | selectattr('connection', 'equalto', 'FC') | map(attribute='inventory_hostname') | list }}"
+
+            - name: Extract iSCSI inventory hostname
+              ansible.builtin.set_fact:
+                iscsi_hosts: "{{ host_matched_list_processed | selectattr('connection', 'equalto', 'iscsi') | map(attribute='inventory_hostname') | list }}"
 
             - name: Call rescan playbook based on hosts discovery status.
               ansible.builtin.command:
                 cmd: "ansible-playbook rescan_multipath_devices.yml -i {{ inventory_file }} -e 'file_name={{ file_path }}'"
               changed_when: false
-              when: (lspartition_output | selectattr('hosts_discovery_status', 'equalto', 'need_rescan') | list | length) > 0
+              when: (lspartition_output | selectattr('hosts_discovery_status', 'equalto', 'need_rescan') | list | length) > 0 and fc_hosts | length != 0
+
+            - name: Call discovery playbook based on hosts discovery status.
+              ansible.builtin.command:
+                cmd: "ansible-playbook discover_multipath_devices.yml -i {{ inventory_file }} -e 'file_name={{ file_path }} rescan_flag=no'"
+              changed_when: false
+              when: (lspartition_output | selectattr('hosts_discovery_status', 'equalto', 'need_rescan') | list | length) > 0 and iscsi_hosts | length != 0
 
             - name: Waiting for IO to stabilize.
               ansible.builtin.wait_for:
                 timeout: "{{ io_stability_time | int }}"
               when: (lspartition_output | selectattr('hosts_discovery_status', 'equalto', 'need_rescan') | list | length) > 0
 
-            - name: Run lspartition on flashsystem to verify the host discovry status.
+            - name: Run lspartition on flashsystem to verify the host discovery status.
               ibm.storage_virtualize.ibm_svcinfo_command:
                 clustername: "{{ ansible_host }}"
                 username: "{{ ansible_user }}"
@@ -226,10 +345,10 @@
               ansible.builtin.set_fact:
                 partition_in_progress_info_output: "{{ (partition_in_progress_info.stdout | from_json) }}"
 
-            - name: Rescan triggerd upto 5 times.
+            - name: Rescan triggered up to 5 times.
               when: partition_in_progress_info_output['hosts_discovery_status'] != 'ready'
               block:
-                - name: Read data povided by host_identification.yml playbook from file.
+                - name: Read data provided by host_identification.yml playbook from file.
                   ansible.builtin.slurp:
                     src: "{{ file_path }}/matched_hosts.json"
                   register: host_matched_list
@@ -279,8 +398,8 @@
       when: (lspartition_output | selectattr('user_action_type', 'equalto', 'commit_or_rollback') | list | length) > 0
       block:
 
-        - name: Validate multipth on target system.
-          when: extracted_hosts | length > 0 and min_active_path != 0 and not is_windows_host and not is_esxi_host
+        - name: Validate multipath on target system.
+          when: extracted_hosts != [] and min_active_path != 0 and not is_windows_host and not is_esxi_host
           block:
 
             - name: Fetch WWNN for Target system.
@@ -308,25 +427,26 @@
                       item.id | int: {
                         "name": item.name,
                         "WWNN": item.WWNN,
+                        "iscsi_name": item.iscsi_name,
                       }
                     })
                   }}
               loop: "{{ targetports_data_tgt }}"
               when: item is not none
 
-            - name: Write extrated data to file to send to verify_multipath_devices playbook.
+            - name: Write extracted data to file to send to verify_multipath_devices playbook.
               delegate_to: localhost
               ansible.builtin.copy:
                 content: "{{ targetports_output_tgt | to_nice_json }}"
                 dest: "{{ file_path }}/vmd_output.json"
                 mode: '0600'
 
-            - name: Call verify multipth devices playbook.
+            - name: Call verify multipath devices playbook.
               ansible.builtin.command:
                 cmd: "ansible-playbook verify_multipath_devices.yml -i {{ inventory_file }} -e 'file_name={{ file_path }}'"
               changed_when: false
 
-            - name: Read output data genrated by verify_multipath_devices playbook.
+            - name: Read output data generated by verify_multipath_devices playbook.
               ansible.builtin.slurp:
                 src: "{{ file_path }}/vmd_output_final_out.json"
               register: json_data
@@ -337,10 +457,13 @@
 
             - name: Set commit flag based on min_active_path.
               ansible.builtin.set_fact:
-                commit_flag: "{{ parsed_data['data'] | selectattr('non_compliant_devices', 'equalto', []) |
-                  list | length > 0 }}"
                 non_compliant_names: "{{ parsed_data['data'] | selectattr('non_compliant_devices', 'ne', []) |
                   map(attribute='active_paths_on_tgt.inventory_name') | list }}"
+
+            - name: Set commit flag based on min_active_path.
+              ansible.builtin.set_fact:
+                commit_flag: false
+              when: non_compliant_names | length > 0
 
             - name: Print non-compliant inventory names.
               ansible.builtin.debug:
@@ -361,13 +484,234 @@
                   - "extracted_hosts_length {{ extracted_hosts_length }}"
                   - "deployment_type {{ deployment_type }}"
 
-            - name: Complete migration (on target system) by running migration action.
-              ibm.storage_virtualize.ibm_sv_manage_storage_partition:
-                clustername: "{{ ansible_host }}"
-                username: "{{ ansible_user }}"
-                password: "{{ ansible_password }}"
-                name: "{{ partition_name }}"
-                migrationaction: fixeventwithchecks
-                state: present
-                log_path: "{{ logpath }}"
+            - name: Commit and logout block
               when: commit_flag and are_all_hosts_in_inventory and single_host_present_flag
+              block:
+
+                - name: Set facts for partition name.
+                  ansible.builtin.set_fact:
+                    partition_name: "{{ migrating_partition[0]['name'] }}"
+
+                - name: Run lspartition on flashsystem to source cluster information.
+                  ibm.storage_virtualize.ibm_svcinfo_command:
+                    clustername: "{{ ansible_host }}"
+                    username: "{{ ansible_user }}"
+                    password: "{{ ansible_password }}"
+                    command: "lspartition -gui -json {{ partition_name }}"
+                    log_path: "{{ logpath }}"
+                  register: partition_in_progress_info
+
+                - name: Clean the lspartition output.
+                  ansible.builtin.set_fact:
+                    partition_in_progress_info_output: "{{ (partition_in_progress_info.stdout | from_json) }}"
+
+                - name: Fetch cluster IP for source system.
+                  ibm.storage_virtualize.ibm_svc_info:
+                    gather_subset: "partnership"
+                    clustername: "{{ ansible_host }}"
+                    username: "{{ ansible_user }}"
+                    password: "{{ ansible_password }}"
+                    objectname: "{{ partition_in_progress_info_output['location1_system_id'] }}"
+                    log_path: "{{ logpath }}"
+                  register: partnership_info
+
+                - name: Cleaning up ip addr
+                  ansible.builtin.set_fact:
+                    ip_only: "{{  partnership_info.Partnership['console_IP'].split(':')[0] }}"
+
+                - name: Find matching hostname for the user-provided IP   # # noqa run-once[task]
+                  ansible.builtin.set_fact:
+                    matched_host: "{{ item }}"
+                  loop: "{{ groups['flash_systems'] }}"
+                  when: hostvars[item].ansible_host == ip_only
+                  run_once: true
+
+                - name: Source side ip logout block
+                  when: matched_host is defined and matched_host | length != 0
+                  block:
+
+                    - name: Setting up source credential
+                      ansible.builtin.set_fact:
+                        source_ansible_host: "{{ hostvars[matched_host]['ansible_host'] }}"
+                        source_ansible_user: "{{ hostvars[matched_host]['ansible_user'] }}"
+                        source_ansible_password: "{{ hostvars[matched_host]['ansible_password'] }}"
+                      delegate_to: "{{ matched_host | default('localhost') }}"
+
+                    - name: Setting up source credential safely
+                      ansible.builtin.set_fact:
+                        source_ansible_host: "{{ hostvars[matched_host | default('')]['ansible_host'] | default('') }}"
+                        source_ansible_user: "{{ hostvars[matched_host | default('')]['ansible_user'] | default('') }}"
+                        source_ansible_password: "{{ hostvars[matched_host | default('')]['ansible_password'] | default('') }}"
+                      when: matched_host is defined and matched_host in hostvars
+
+                    - name: Gather lshost information from flashsystem.
+                      ibm.storage_virtualize.ibm_svc_info:
+                        clustername: "{{ source_ansible_host }}"
+                        username: "{{ source_ansible_user }}"
+                        password: "{{ source_ansible_password }}"
+                        log_path: "{{ logpath }}"
+                        gather_subset: "host"
+                        filtervalue: 'partition_name={{ partition_name }}'
+                      register: lshost_output
+                      changed_when: false
+
+                    - name: Gather details of each host on flashsystem.
+                      ibm.storage_virtualize.ibm_svc_info:
+                        gather_subset: "host"
+                        clustername: "{{ source_ansible_host }}"
+                        username: "{{ source_ansible_user }}"
+                        password: "{{ source_ansible_password }}"
+                        objectname: "{{ item.id }}"
+                        log_path: "{{ logpath }}"
+                      changed_when: false
+                      register: shared_targetports_output
+                      loop: "{{ lshost_output.Host }}"
+
+                    - name: Initialize extracted_hosts_form_source list.
+                      ansible.builtin.set_fact:
+                        extracted_hosts_form_source: {}
+                        extracted_hosts_form_source_tmp: []
+
+                    - name: Extract relevant iscsi host data for the identified partition for extracted_hosts_form_source.
+                      ansible.builtin.set_fact:
+                        extracted_hosts_form_source: >-
+                          {{
+                            extracted_hosts_form_source | combine({
+                              item.Host.id | int: {
+                                "inventory_hostname": inventory_hostname,
+                                "name": item.Host.name,
+                                "iscsi_name": item.Host.nodes | default([]) | map(attribute='iscsi_name') | list,
+                                "partition": item.Host.partition_name | default(""),
+                                "portset_name":item.Host.portset_name,
+                                "type": 'iscsi'
+                              }
+                            })
+                          }}
+                      loop: "{{ shared_targetports_output.results }}"
+                      when: item.Host is not none and item.Host.nodes[0].iscsi_name is defined
+
+                    - name: Process extracted host data if not empty.
+                      when: extracted_hosts_form_source | length != 0
+                      block:
+
+                        - name: Gather lsportset information from flashsystem.
+                          ibm.storage_virtualize.ibm_svc_info:
+                            gather_subset: "portset"
+                            clustername: "{{ source_ansible_host }}"
+                            username: "{{ source_ansible_user }}"
+                            password: "{{ source_ansible_password }}"
+                            objectname: "{{ item.value.portset_name }}"
+                            log_path: "{{ logpath }}"
+                          changed_when: false
+                          register: portset_info
+                          loop: "{{ extracted_hosts_form_source | dict2items }}"
+                          when: item.value.type == 'iscsi'
+
+                        - name: Build host entries for extracted_hosts_form_source
+                          ansible.builtin.set_fact:
+                            extracted_hosts_form_source_tmp: >-
+                              {{
+                                extracted_hosts_form_source_tmp | default([]) + [
+                                  {
+                                    (item.item.key | string): (
+                                      item.item.value | combine(
+                                        (
+                                          {'replication_portset_link_uid': item.Portset.replication_portset_link_uid}
+                                          if item.item.value.type == 'iscsi'
+                                          else {}
+                                        )
+                                      )
+                                    )
+                                  }
+                                ]
+                              }}
+                          loop: "{{ portset_info.results }}"
+                          when: item.item is defined and item.item.value is defined
+
+                        - name: Combine extracted_hosts_form_source into a single dict
+                          ansible.builtin.set_fact:
+                            extracted_hosts_form_source: "{{ extracted_hosts_form_source_tmp | default([]) | combine }}"
+
+                        - name: Gather lsip information from flashsystem.
+                          ibm.storage_virtualize.ibm_svcinfo_command:
+                            clustername: "{{ source_ansible_host }}"
+                            username: "{{ source_ansible_user }}"
+                            password: "{{ source_ansible_password }}"
+                            command: "lsip -json"
+                            log_path: "{{ logpath }}"
+                          register: ip_info
+
+                        - name: Convert raw ip_info.stdout string to structured data
+                          ansible.builtin.set_fact:
+                            ip_info_parsed: "{{ ip_info.stdout | from_json }}"
+
+                        - name: Add iscsi_ips to extracted_hosts
+                          ansible.builtin.set_fact:
+                            extracted_hosts_form_source: >-
+                              {%- set updated_hosts = {} -%}
+                              {%- for key, host in extracted_hosts_form_source .items() -%}
+                                {%- set _host = host.copy() -%}
+                                {%- if 'type' in _host and _host['type'] == 'iscsi' and 'portset_name' in _host -%}
+                                  {%- set ips = [] -%}
+                                  {%- for ip in ip_info_parsed -%}
+                                    {%- if 'portset_name' in ip and
+                                            (ip['portset_name'] | string | lower | trim) == (_host['portset_name'] | string | lower | trim) and
+                                            'IP_address' in ip -%}
+                                      {%- set _ = ips.append(ip['IP_address']) -%}
+                                    {%- endif -%}
+                                  {%- endfor -%}
+                                  {%- set _ = _host.update({'iscsi_ips': ips}) -%}
+                                {%- endif -%}
+                                {%- set _ = updated_hosts.update({ key: _host }) -%}
+                              {%- endfor -%}
+                              {{ updated_hosts }}
+
+                        - name: Write extracted_hosts_form_source  information to file.
+                          ansible.builtin.copy:
+                            content: "{{ extracted_hosts_form_source | to_nice_json }}"
+                            dest: "{{ file_path }}/svc_host_obj_list_present_source.json"
+                            mode: '0600'
+                          delegate_to: localhost
+
+                        - name: Call Host_identification playbook to fetch list of host mapped to flashsystem.
+                          ansible.builtin.command:
+                            cmd: >
+                              ansible-playbook host_identification.yml
+                              -i {{ inventory_file }}
+                              -e 'file_name={{ file_path }}
+                              json_file=svc_host_obj_list_present_source.json
+                              location_flag=source'
+                          changed_when: false
+
+                - name: Complete migration (on target system) by running migration action.
+                  ibm.storage_virtualize.ibm_sv_manage_storage_partition:
+                    clustername: "{{ ansible_host }}"
+                    username: "{{ ansible_user }}"
+                    password: "{{ ansible_password }}"
+                    name: "{{ partition_name }}"
+                    migrationaction: fixeventwithchecks
+                    state: present
+                    log_path: "{{ logpath }}"
+                  when: matched_host is defined and matched_host | length != 0
+
+                - name: Wait for either migration_status = "" to complete the migration
+                  ibm.storage_virtualize.ibm_svc_info:
+                    clustername: "{{ ansible_host }}"
+                    username: "{{ ansible_user }}"
+                    password: "{{ ansible_password }}"
+                    gather_subset: partition
+                    objectname: "{{ partition_name }}"
+                  register: lspartition_out
+                  until: lspartition_out.Partition['migration_status'] == ''
+                  retries: 60
+                  delay: 30
+
+                - name: Call iscsi_logout playbook to logout
+                  ansible.builtin.command:
+                    cmd: "ansible-playbook iscsi_logout.yml -i {{ inventory_file }} -e 'file_name={{ file_path }}'"
+                  changed_when: false
+                  when:
+                    - matched_host is defined
+                    - matched_host | length > 0
+                    - extracted_hosts_form_source is defined
+                    - extracted_hosts_form_source | length > 0

--- a/playbooks/partition_migration_host_actions/rescan_multipath_devices.yml
+++ b/playbooks/partition_migration_host_actions/rescan_multipath_devices.yml
@@ -3,7 +3,7 @@
   gather_facts: false
   tasks:
 
-    - name: Read data povided by host_identification.yml playbook from file.
+    - name: Read data provided by host_identification.yml playbook from file.
       ansible.builtin.slurp:
         src: "{{ file_name }}/matched_hosts.json"
       register: vmd_host_matched_list
@@ -12,10 +12,15 @@
       ansible.builtin.set_fact:
         host_matched_list_processed: "{{ vmd_host_matched_list['content'] | b64decode | from_json }}"
 
-    - name: Extract inventory_hostnames from input list
+    - name: Extract FC inventory hostname
       ansible.builtin.set_fact:
-        vmd_host_matched_list_processed: "{{ host_matched_list_processed | map(attribute='inventory_hostname') | list }}"
-
+        vmd_host_matched_list_processed: >-
+          {{
+            host_matched_list_processed
+            | selectattr('connection', 'equalto', 'FC')
+            | map(attribute='inventory_hostname')
+            | list
+          }}
 
 - name: Rescan and verify SCSI devices and multipath
   hosts: "{{ hostvars['localhost'].vmd_host_matched_list_processed | default([]) }}"

--- a/playbooks/partition_migration_host_actions/test_and_rescan_hosts.yml
+++ b/playbooks/partition_migration_host_actions/test_and_rescan_hosts.yml
@@ -12,9 +12,10 @@
 
 - name: Initialize extracted_hosts list
   ansible.builtin.set_fact:
-    extracted_hosts1: {}
+    extracted_hosts1: []
+    extracted_hosts_tmp1: []
 
-- name: Extract relevant data
+- name: Extract relevant fc host data for the identified partition.
   ansible.builtin.set_fact:
     extracted_hosts1: >-
       {{
@@ -24,44 +25,130 @@
             "name": item.Host.name,
             "wwpns": item.Host.nodes | default([]) | map(attribute='WWPN') | list,
             "partition": item.Host.partition_name | default(""),
-            "discovery_status": item.Host.discovery_status
+            "discovery_status": item.Host.discovery_status,
+            "type": "FC"
           }
         })
       }}
   loop: "{{ shared_targetports_output1.results }}"
-  when: item.Host.partition_name == partition_name and  item.Host.discovery_status != 'ready'
+  when: item.Host.partition_name == partition_name and item.Host.discovery_status != 'ready' and item.Host.nodes[0].WWPN is defined
 
-
-- name: Extract all host names from extracted_hosts
+- name: Extract relevant iscsi host data for the identified partition.
   ansible.builtin.set_fact:
-    extracted_host_names: "{{ extracted_hosts1.values() | map(attribute='name') | list }}"
+    extracted_hosts1: >-
+      {{
+        extracted_hosts | combine({
+          item.Host.id | int: {
+            "inventory_hostname": inventory_hostname,
+            "name": item.Host.name,
+            "iscsi_name": item.Host.nodes | default([]) | map(attribute='iscsi_name') | list,
+            "partition": item.Host.partition_name | default(""),
+            "portset_name":item.Host.portset_name,
+            "type": 'iscsi'
+          }
+        })
+      }}
+  loop: "{{ shared_targetports_output.results }}"
+  when: item.Host.partition_name == partition_name and item.Host.discovery_status != 'ready' and item.Host.nodes[0].iscsi_name is defined
 
-- name: Filter host_matched_list_processed based on extracted_hosts
+- name: Build host entries for extracted_hosts
   ansible.builtin.set_fact:
-    filtered_host_matched_list: "{{ host_matched_list_processed | selectattr('fs_host_name', 'in', extracted_host_names) | list }}"
+    extracted_hosts_tmp1: >-
+      {{
+        extracted_hosts_tmp | default([]) + [
+          {
+            (item.item.key | string): (
+              item.item.value | combine(
+                (
+                  {'replication_portset_link_uid': item.Portset.replication_portset_link_uid}
+                  if item.item.value.type == 'iscsi'
+                  else {}
+                )
+              )
+            )
+          }
+        ]
+      }}
+  loop: "{{ portset_info.results }}"
+  when: item.item is defined and item.item.value is defined
 
-- name: Debug filtered_host_matched_list
+- name: Combine extracted_hosts_tmp into a single dict
+  ansible.builtin.set_fact:
+    extracted_hosts1: "{{ extracted_hosts_tmp1 | default([]) | combine }}"
+
+# for fc hosts
+- name: Extract all fc host names from extracted_hosts1
+  ansible.builtin.set_fact:
+    extracted_host_names_fc: "{{ extracted_hosts1.values() | selectattr('type', 'equalto', 'FC') | map(attribute='name') | list }}"
+
+- name: Filter host_matched_list_processed_fc based on extracted_hosts1
+  ansible.builtin.set_fact:
+    filtered_host_matched_list_fc: >-
+      {{
+        host_matched_list_processed
+        | selectattr('fs_host_name', 'defined')
+        | selectattr('fs_host_name', 'in', extracted_host_names_fc)
+        | list
+      }}
+
+- name: Debug filtered_host_matched_list_fc
   ansible.builtin.debug:
-    var: filtered_host_matched_list
+    var: filtered_host_matched_list_fc
 
-- name: Save filtered hosts to JSON file
+- name: Save filtered hosts fc to JSON file
   ansible.builtin.copy:
-    content: "{{ filtered_host_matched_list | to_nice_json }}"
+    content: "{{ filtered_host_matched_list_fc | to_nice_json }}"
     dest: "{{ file_path }}/matched_hosts.json"
     mode: '0644'
+  when: filtered_host_matched_list_fc != []
 
-- name: Check and include rescan tasks if needed then rescan the multipth
+- name: Check and include rescan tasks if needed then rescan the multipath
   ansible.builtin.command:
     cmd: "ansible-playbook rescan_multipath_devices.yml -i {{ inventory_file }} -e 'file_name={{ file_path }}'"
   changed_when: false
-  when: filtered_host_matched_list | length > 0
+  when: filtered_host_matched_list_fc != []
 
 - name: Waiting for IO to stabilize.
   ansible.builtin.wait_for:
     timeout: "{{ io_stability_time | int }}"
-  when: filtered_host_matched_list | length > 0
+  when: filtered_host_matched_list_fc != []
 
-- name: Run lspartition on flashsystem to verify the host discovry status
+# for iscsi hosts
+- name: Extract all host names from extracted_hosts
+  ansible.builtin.set_fact:
+    extracted_host_names_iscsi: "{{ extracted_hosts1.values() | selectattr('type', 'equalto', 'iscsi') | map(attribute='name') | list }}"
+
+- name: Filter host_matched_list_processed based on extracted_hosts
+  ansible.builtin.set_fact:
+    filtered_host_matched_list_iscsi: >-
+      {{
+        host_matched_list_processed
+        | selectattr('iscsi_host_name', 'defined')
+        | selectattr('iscsi_host_name', 'in', extracted_host_names_iscsi)
+        | list
+      }}
+- name: Debug filtered_host_matched_list
+  ansible.builtin.debug:
+    var: filtered_host_matched_list_iscsi
+
+- name: Save filtered hosts iscsi to JSON file
+  ansible.builtin.copy:
+    content: "{{ filtered_host_matched_list_iscsi | to_nice_json }}"
+    dest: "{{ file_path }}/matched_hosts.json"
+    mode: '0644'
+
+- name: Check and include rescan tasks if needed then rescan the multipath
+  ansible.builtin.command:
+    cmd: "ansible-playbook discover_multipath_devices.yml -i {{ inventory_file }} -e 'file_name={{ file_path }} rescan_flag=yes'"
+  changed_when: false
+  when: filtered_host_matched_list_iscsi != []
+
+- name: Waiting for IO to stabilize.
+  ansible.builtin.wait_for:
+    timeout: "{{ io_stability_time | int }}"
+  when: filtered_host_matched_list_iscsi != []
+
+- name: Run lspartition on flashsystem to verify the host discovery status
   ibm.storage_virtualize.ibm_svcinfo_command:
     clustername: "{{ ansible_host }}"
     username: "{{ ansible_user }}"

--- a/playbooks/partition_migration_host_actions/vars.yml
+++ b/playbooks/partition_migration_host_actions/vars.yml
@@ -1,7 +1,7 @@
-min_active_path: 1               # To skip commit action set this to 0
+min_active_path: 0               # To skip commit action set this to 0
 hosts_name: application_server   # localhost/webserver/application_server
 deployment_type: 2               # 1: for localhost 2: for ansible tower
-io_stability_time: 90
-inventory_file: pm_inventory.ini
+io_stability_time: 60
+inventory_file: inventory.ini
 logpath: /tmp/playbook.debug
 temp_file_location: /tmp

--- a/playbooks/partition_migration_host_actions/verify_multipath_devices.yml
+++ b/playbooks/partition_migration_host_actions/verify_multipath_devices.yml
@@ -4,7 +4,7 @@
   gather_facts: true
   tasks:
 
-    - name: Read data povided by host_identification.yml playbook from file.
+    - name: Read data provided by host_identification.yml playbook from file.
       ansible.builtin.slurp:
         src: "{{ file_name }}/matched_hosts.json"
       register: vmd_host_matched_list
@@ -13,10 +13,16 @@
       ansible.builtin.set_fact:
         host_matched_list_processed: "{{ vmd_host_matched_list['content'] | b64decode | from_json }}"
 
-    - name: Extract inventory_hostnames from input list
+    - name: Extract inventory_hostname from input list
       ansible.builtin.set_fact:
         vmd_host_matched_list_processed: "{{ host_matched_list_processed | map(attribute='inventory_hostname') | list }}"
 
+    - name: Create hostname to connection map
+      ansible.builtin.set_fact:
+        connection_map: >-
+          {{
+            dict(host_matched_list_processed | map(attribute='inventory_hostname') | zip(host_matched_list_processed | map(attribute='connection')))
+          }}
 
 - name: Rescan and verify SCSI devices and multipath
   hosts: "{{ hostvars['localhost'].vmd_host_matched_list_processed | default([]) }}"
@@ -24,6 +30,10 @@
     - vars.yml
   serial: 1
   tasks:
+
+    - name: Set connection info
+      ansible.builtin.set_fact:
+        connection_type: "{{ hostvars['localhost'].connection_map[inventory_hostname] }}"
 
     - name: Gather facts for all hosts.
       ansible.builtin.setup:
@@ -243,52 +253,99 @@
           ansible.builtin.set_fact:
             active_paths_on_tgt: {}
 
-        - name: Process data and generate output.
-          ansible.builtin.set_fact:
-            active_paths_on_tgt: >-
-              {%- set result = active_paths_on_tgt.copy() -%}
-              {%- for key, value in final_out.items() -%}
-                {%- set dm = value.dm -%}
-                {%- set uuid = key -%}
-                {%- if dm not in result -%}
-                  {%- set _ = result.update({dm: {}}) -%}
-                {%- endif -%}
-                {%- set _ = result[dm].update({'uuid': uuid}) -%}
-                {%- for tgt_id, tgt_data in targetports_output_tgt.items() -%}
-                  {%- set node_name = tgt_data.name -%}
-                  {%- set wwnn = tgt_data.WWNN -%}
-                  {%- set active_count = value.active.get('0x' + wwnn, []) | length -%}
-                  {%- set inactive_count = value.inactive.get('0x' + wwnn, []) | length -%}
-                  {%- set _ = result[dm].update({node_name: {'active_no_paths': active_count, 'inactive_no_paths': inactive_count}}) -%}
-                {%- endfor -%}
-              {%- endfor -%}
-              {%- set _ = result.update({'inventory_name': inventory_hostname}) -%}
-              {{ result }}
-
-
         - name: Initialize path analysis variables
           ansible.builtin.set_fact:
             non_compliant_devices: []
 
+        - name: Process data and generate output for fc block.
+          when: connection_type == "FC"
+          block:
 
-        - name: Identify non-compliant devices
-          ansible.builtin.set_fact:
-            non_compliant_devices: >-
-              {%- set result = non_compliant_devices -%}
-              {%- for device, data in final_out.items() -%}
-                {%- set dm_name = data['dm'] -%}
-                {%- for port, targets in targetports_output_tgt.items() -%}
-                  {%- set wwnn = targets.WWNN -%}
-                  {%- set active_count = data.active.get('0x' + wwnn, []) | length -%}
-                  {%- if active_count < min_active_path -%}
-                    {%- for tgt in targets -%}
-                      {%- set _ = result.append("Device: {} {} port {} WWNN {} does not meet min path requirement which is
-                       {}".format(device, dm_name, port, tgt, min_active_path)) -%}
+            - name: Process data and generate output for fc.
+              ansible.builtin.set_fact:
+                active_paths_on_tgt: >-
+                  {%- set result = active_paths_on_tgt.copy() -%}
+                  {%- for key, value in final_out.items() -%}
+                    {%- set dm = value.dm -%}
+                    {%- set uuid = key -%}
+                    {%- if dm not in result -%}
+                      {%- set _ = result.update({dm: {}}) -%}
+                    {%- endif -%}
+                    {%- set _ = result[dm].update({'uuid': uuid}) -%}
+                    {%- for tgt_id, tgt_data in targetports_output_tgt.items() -%}
+                      {%- set node_name = tgt_data.name -%}
+                      {%- set wwnn = tgt_data.WWNN -%}
+                      {%- set active_count = value.active.get('0x' + wwnn, []) | length -%}
+                      {%- set inactive_count = value.inactive.get('0x' + wwnn, []) | length -%}
+                      {%- set _ = result[dm].update({node_name: {'active_no_paths': active_count, 'inactive_no_paths': inactive_count}}) -%}
                     {%- endfor -%}
-                  {%- endif -%}
-                {%- endfor -%}
-              {%- endfor -%}
-              {{ result }}
+                  {%- endfor -%}
+                  {%- set _ = result.update({'inventory_name': inventory_hostname}) -%}
+                  {{ result }}
+
+            - name: Identify non-compliant devices for fc
+              ansible.builtin.set_fact:
+                non_compliant_devices: >-
+                  {%- set result = non_compliant_devices -%}
+                  {%- for device, data in final_out.items() -%}
+                    {%- set dm_name = data['dm'] -%}
+                    {%- for port, targets in targetports_output_tgt.items() -%}
+                      {%- set wwnn = targets.WWNN -%}
+                      {%- set active_count = data.active.get('0x' + wwnn, []) | length -%}
+                      {%- if active_count < min_active_path -%}
+                        {%- for tgt in targets -%}
+                          {%- set _ = result.append("Device: {} {} port {} WWNN {} does not meet min path requirement which is
+                          {}".format(device, dm_name, port, tgt, min_active_path)) -%}
+                        {%- endfor -%}
+                      {%- endif -%}
+                    {%- endfor -%}
+                  {%- endfor -%}
+                  {{ result }}
+
+        - name: Process data and generate output for iscsi block.
+          when: connection_type == "iscsi"
+          block:
+
+            - name: Process data and generate output for iscsi.
+              ansible.builtin.set_fact:
+                active_paths_on_tgt: >-
+                  {%- set result = active_paths_on_tgt.copy() -%}
+                  {%- for key, value in final_out.items() -%}
+                    {%- set dm = value.dm -%}
+                    {%- set uuid = key -%}
+                    {%- if dm not in result -%}
+                      {%- set _ = result.update({dm: {}}) -%}
+                    {%- endif -%}
+                    {%- set _ = result[dm].update({'uuid': uuid}) -%}
+                    {%- for tgt_id, tgt_data in targetports_output_tgt.items() -%}
+                      {%- set node_name = tgt_data.name -%}
+                      {%- set iscsi_name = tgt_data.iscsi_name -%}
+                      {%- set active_count = value.active.get(iscsi_name, []) | length -%}
+                      {%- set inactive_count = value.inactive.get(iscsi_name, []) | length -%}
+                      {%- set _ = result[dm].update({node_name: {'active_no_paths': active_count, 'inactive_no_paths': inactive_count}}) -%}
+                    {%- endfor -%}
+                  {%- endfor -%}
+                  {%- set _ = result.update({'inventory_name': inventory_hostname}) -%}
+                  {{ result }}
+
+            - name: Identify non-compliant devices for iscsi
+              ansible.builtin.set_fact:
+                non_compliant_devices: >-
+                  {%- set result = non_compliant_devices -%}
+                  {%- for device, data in final_out.items() -%}
+                    {%- set dm_name = data['dm'] -%}
+                    {%- for port, targets in targetports_output_tgt.items() -%}
+                      {%- set iscsi_name = targets.iscsi_name -%}
+                      {%- set active_count = data.active.get(iscsi_name, []) | length -%}
+                      {%- if active_count < min_active_path -%}
+                        {%- for tgt in targets -%}
+                          {%- set _ = result.append("Device: {} {} port {} iscsi_name {} does not meet min path requirement which is
+                          {}".format(device, dm_name, port, tgt, min_active_path)) -%}
+                        {%- endfor -%}
+                      {%- endif -%}
+                    {%- endfor -%}
+                  {%- endfor -%}
+                  {{ result }}
 
         - name: Display analysis results
           ansible.builtin.debug:

--- a/plugins/module_utils/ibm_svc_ssh.py
+++ b/plugins/module_utils/ibm_svc_ssh.py
@@ -15,7 +15,7 @@ import uuid
 from ansible.module_utils.compat.paramiko import paramiko
 from ansible_collections.ibm.storage_virtualize.plugins.module_utils.ibm_svc_utils import get_logger
 
-COLLECTION_VERSION = "3.1.0"
+COLLECTION_VERSION = "3.2.0"
 
 
 class IBMSVCssh(object):

--- a/plugins/module_utils/ibm_svc_utils.py
+++ b/plugins/module_utils/ibm_svc_utils.py
@@ -20,7 +20,7 @@ from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 
-COLLECTION_VERSION = "3.1.0"
+COLLECTION_VERSION = "3.2.0"
 TIMEOUT = 600
 
 

--- a/plugins/modules/ibm_sv_manage_clone.py
+++ b/plugins/modules/ibm_sv_manage_clone.py
@@ -1,0 +1,461 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2021 IBM CORPORATION
+# Author(s): Sandip Gulab Rajbanshi <sandip.rajbanshi@ibm.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: ibm_sv_manage_clone
+short_description: This module manages clone and thinclone of volume and volumegroup
+version_added: '3.2.0'
+description:
+  - Ansible interface to manage 'mkvolume' and 'mkvolumegroup' clone commands.
+options:
+    clustername:
+        description:
+            - The hostname, management IP or partition IP of the Storage Virtualize system.
+        required: true
+        type: str
+    domain:
+        description:
+            - Domain for the Storage Virtualize system.
+            - Valid when hostname is used for the parameter I(clustername).
+        type: str
+    username:
+        description:
+            - REST API username for the Storage Virtualize system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    password:
+        description:
+            - REST API password for the Storage Virtualize system.
+            - The parameters I(username) and I(password) are required if not using I(token) to authenticate a user.
+        type: str
+    token:
+        description:
+            - The authentication token to verify a user on the Storage Virtualize system.
+            - To generate a token, use the M(ibm.storage_virtualize.ibm_svc_auth) module.
+        type: str
+    log_path:
+        description:
+            - Path of debug log file.
+        type: str
+    state:
+        description:
+            - Creates (C(present)) or removes (C(absent)) the clone object.
+        choices: [ 'absent', 'present' ]
+        required: true
+        type: str
+    name:
+        description:
+            - Specifies a name for the new clone.
+        required: true
+        type: str
+    pool:
+        description:
+            - Specifies the name of the storage pool to use while creating the clone.
+            - The parameters I(pool) is mandatory for clone volumes and optional for clone volume groups while
+              creating clone.
+        type: str
+    iogrp:
+        description:
+            - Specifies the name of the I/O group for the new clone.
+        type: str
+    volumegroup:
+        description:
+            - Specifies the name of the volumegroup to which the clone is to be added.
+            - When logging in via partition IP, the I(volumegroup) parameter is required to create a volume clone.
+        type: str
+    type:
+        description:
+            - Specifies the type of clone to create. Volume can be thinclone or clone type.
+        choices: [ 'clone', 'thinclone' ]
+        type: str
+    fromsourcevolumes:
+        description:
+            - Specifies colon-separated list of the parent volumes.
+            - The parameters I(fromsourcevolumes) is mandatory for clone volumes and optional for clone volume groups
+              while creating clone.
+        type: str
+    snapshot:
+        description:
+            - Specifies the name of the snapshot that is used to create the clone.
+            - The parameters I(fromsourcevolumes) is mandatory for creating clone.
+        type: str
+    preferrednode:
+        description:
+            - Specifies the preferred node that is used to access the volume.
+        type: str
+    partition:
+        description:
+            - Specifies the name of the storage partition to be assigned to the volume group.
+        type: str
+    ownershipgroup:
+        description:
+            - Specifies the name of the ownership group to which the object is being added.
+        type: str
+    ignoreuserfcmaps:
+        description:
+            - Indicates that snapshots can be created with the scheduler or with the addsnapshot command,
+              if any volumes in the volume group are used as a source volume in legacy FlashCopy mapping.
+        choices: [ 'yes', 'no' ]
+        type: str
+    validate_certs:
+        description:
+            - Validates certification.
+        default: false
+        type: bool
+author:
+    - Sandip G. Rajbanshi (@Sandip-Rajbanshi)
+notes:
+    - This module supports C(check_mode).
+    - This module currently only supports the creation of clone volume or volumegroup (C(state=present)).
+    - Support for updating or removing these clone objects may be added in a future release. For updating (converting
+      thinclone to clone) or removing thinclone or clone for volume and volumegroup, use the I(ibm_svc_manage_volume) or
+      I(ibm_svc_manage_volumegroup) modules, respectively.
+    - This module supports log-in via partition-ip.
+'''
+
+EXAMPLES = r'''
+- name: Create a clone of a volume from snapshot
+  ibm.storage_virtualize.ibm_svc_manage_clone:
+    clustername: "{{ clustername }}"
+    domain: "{{ domain }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    log_path: "{{ log_path }}"
+    name: "vol1_clone_1"
+    state: "present"
+    pool: "pool1"
+    type: "clone"
+    snapshot: "snapshot1"
+    fromsourcevolumes: "vol1"
+    iogrp: "io_grp0"
+    preferrednode: "node1"
+    volumegroup: "Vg1"
+- name: Create a clone of a volumegroup from snapshot
+  ibm.storage_virtualize.ibm_svc_manage_clone:
+    clustername: "{{ clustername }}"
+    domain: "{{ domain }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    log_path: "{{ log_path }}"
+    name: "vg1_clone_1"
+    state: "present"
+    pool: "pool1"
+    type: "clone"
+    snapshot: "snapshot1"
+    iogrp: "io_grp0"
+    partition: "ptn1"
+    ownershipgroup: "grp1"
+- name: Create a clone of volume vector from snapshot
+  ibm.storage_virtualize.ibm_svc_manage_clone:
+    clustername: "{{ clustername }}"
+    domain: "{{ domain }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    log_path: "{{ log_path }}"
+    name: "vg1_clone_1"
+    state: "present"
+    fromsourcevolumes: "vol1:vol2:vol3"
+    pool: "pool1"
+    type: "clone"
+    snapshot: "snapshot1"
+    iogrp: "io_grp0"
+    partition: "ptn1"
+    ownershipgroup: "grp1"
+'''
+
+RETURN = '''#'''
+
+from traceback import format_exc
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.ibm.storage_virtualize.plugins.module_utils.ibm_svc_utils import (
+    IBMSVCRestApi,
+    svc_argument_spec,
+    get_logger
+)
+from ansible.module_utils._text import to_native
+
+
+class IBMSVClone(object):
+    def __init__(self):
+        argument_spec = svc_argument_spec()
+
+        argument_spec.update(
+            dict(
+                name=dict(type='str', required=True),
+                state=dict(type='str', required=True, choices=['absent', 'present']),
+                pool=dict(type='str', required=False),
+                iogrp=dict(type='str', required=False),
+                volumegroup=dict(type='str', required=False),
+                type=dict(type='str', required=False, choices=['clone', 'thinclone']),
+                fromsourcevolumes=dict(type='str', required=False),
+                log_path=dict(type='str', required=False),
+                snapshot=dict(type='str', required=False),
+                preferrednode=dict(type='str', required=False),
+                partition=dict(type='str', required=False),
+                ownershipgroup=dict(type='str', required=False),
+                ignoreuserfcmaps=dict(type='str', required=False, choices=['yes', 'no'])
+            )
+        )
+
+        self.module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+        # logging setup
+        log_path = self.module.params['log_path']
+        log = get_logger(self.__class__.__name__, log_path)
+        self.log = log.info
+
+        # Required Parameters
+        self.name = self.module.params['name']
+        self.state = self.module.params['state']
+
+        # Optional Parameters
+        self.pool = self.module.params.get('pool', "")
+        self.iogrp = self.module.params.get('iogrp', "")
+        self.volumegroup = self.module.params.get('volumegroup', "")
+        self.type = self.module.params.get('type', "")
+        self.fromsourcevolumes = self.module.params.get('fromsourcevolumes', "")
+        self.fromsourcevolumes_list = self.fromsourcevolumes.split(':') if self.fromsourcevolumes else []
+        self.snapshot = self.module.params.get('snapshot', "")
+        self.preferrednode = self.module.params.get('preferrednode', "")
+        self.partition = self.module.params.get('partition', "")
+        self.ownershipgroup = self.module.params.get('ownershipgroup', "")
+        self.ignoreuserfcmaps = self.module.params.get('ignoreuserfcmaps', "")
+
+        # internal variable
+        self.changed = False
+        self.msg = ""
+        self.OBJECT_TYPE = None
+
+        self.basic_checks()
+
+        self.restapi = IBMSVCRestApi(
+            module=self.module,
+            clustername=self.module.params['clustername'],
+            domain=self.module.params['domain'],
+            username=self.module.params['username'],
+            password=self.module.params['password'],
+            validate_certs=self.module.params['validate_certs'],
+            log_path=log_path,
+            token=self.module.params['token']
+        )
+
+    def basic_checks(self):
+        if len(self.fromsourcevolumes_list) == 1:
+            self.OBJECT_TYPE = 'volume'
+        else:
+            self.OBJECT_TYPE = 'volumegroup'
+        if self.state == 'present':
+            if self.OBJECT_TYPE == 'volume':
+                invalids = ('partition', 'ownershipgroup', 'ignoreuserfcmaps')
+                invalid_exists = ', '.join((var for var in invalids if not getattr(self, var) in {'', None}))
+                if invalid_exists:
+                    self.module.fail_json(
+                        msg='Volume clone operation does not support the parameter(s): {0}'.format(invalid_exists)
+                    )
+            else:
+                invalids = ('volumegroup', 'preferrednode')
+                invalid_exists = ', '.join((var for var in invalids if not getattr(self, var) in {'', None}))
+                if invalid_exists:
+                    self.module.fail_json(
+                        msg='Volumegroup clone operation does not support the parameter(s): {0}'.format(invalid_exists)
+                    )
+        else:
+            self.module.fail_json(
+                msg="Removal of clone is not supported via this module. Please use ibm_svc_manage_volume or"
+                " ibm_svc_manage_volumegroup for removing volume or volumegroup clone/thinclone respectively.")
+
+    def get_existing_clone(self):
+        merged_result = {}
+        cmd = "lsvdisk" if self.OBJECT_TYPE == "volume" else "lsvolumegroup"
+        data = self.restapi.svc_obj_info(cmd, {"bytes": True}, [self.name])
+
+        if isinstance(data, list):
+            for d in data:
+                merged_result.update(d)
+        else:
+            merged_result = data
+        return merged_result
+
+    # Funciton to check whether all volumes inside the volumegroup belonging to the same pool
+    def check_volumes_in_pool(self, vg_name, pool_name):
+        vol_list = self.restapi.svc_obj_info("lsvdisk", {"filtervalue" : "volume_group_name=%s" % vg_name}, [])
+        for vol in vol_list:
+            if self.fromsourcevolumes_list and vol.get("name") not in self.fromsourcevolumes_list:
+                continue
+            if pool_name != vol.get("mdisk_grp_name"):
+                self.log("One or more volumes belonging to volumegroup (%s) are in different pool", vg_name)
+                return False
+        return True
+
+    def get_parent_uid_or_source_grp_from_snapshot(self):
+        parent_uid = None
+        source_grp_name = None
+        if self.OBJECT_TYPE == "volume":
+            snapshot_data = self.restapi.svc_obj_info(
+                'lsvolumesnapshot', {'filtervalue': "snapshot_name=%s" % self.snapshot}, []
+            )
+            if snapshot_data:
+                source_grp_name = snapshot_data[0].get('volume_group_name')
+                parent_uid = snapshot_data[0].get('parent_uid')
+        else:
+            snapshot_data = self.restapi.svc_obj_info(
+                'lsvolumegroupsnapshot', {}, []
+            )
+            for snapshot in snapshot_data:
+                if snapshot.get('name') == self.snapshot:
+                    source_grp_name = snapshot.get('volume_group_name')
+                    parent_uid = snapshot.get('parent_uid')
+                    break
+        if not parent_uid:
+            self.module.fail_json(
+                msg="Snapshot %s does not exist." % self.snapshot
+            )
+        if source_grp_name:
+            return (source_grp_name, None)
+        return (None, parent_uid)
+
+    def create_validation(self):
+        required_params = {
+            "snapshot": self.snapshot,
+            "type": self.type
+        }
+        if self.OBJECT_TYPE == 'volume':
+            required_params["pool"] = self.pool
+
+        missing = [k for k, v in required_params.items() if not v]
+
+        if missing:
+            self.module.fail_json(
+                msg="Following parameters are required while creating clone: {}".format(
+                    ", ".join(missing)
+                )
+            )
+
+    def create_clone(self):
+        self.create_validation()
+        cmdopts = {
+            'name': self.name,
+            'type': self.type,
+            'snapshot': self.snapshot,
+        }
+        source_grp_name, parent_uid = self.get_parent_uid_or_source_grp_from_snapshot()
+        if source_grp_name:
+            cmdopts['fromsourcegroup'] = source_grp_name
+        elif parent_uid:
+            cmdopts['fromsourceuid'] = parent_uid
+
+        if self.OBJECT_TYPE == 'volume':
+            cmd = 'mkvolume'
+            cmdopts['fromsourcevolume'] = self.fromsourcevolumes
+            if self.iogrp:
+                cmdopts['iogrp'] = self.iogrp
+        else:
+            cmd = 'mkvolumegroup'
+            if self.fromsourcevolumes:
+                cmdopts['fromsourcevolumes'] = self.fromsourcevolumes
+            if self.iogrp:
+                cmdopts['iogroup'] = self.iogrp
+
+        # Optional fields (add only if defined)
+        optional_fields = {
+            'pool': self.pool,
+            'volumegroup': self.volumegroup,
+            'preferrednode': self.preferrednode,
+            'partition': self.partition,
+            'ownershipgroup': self.ownershipgroup,
+            'ignoreuserfcmaps': self.ignoreuserfcmaps,
+        }
+
+        for key, value in optional_fields.items():
+            if value:
+                cmdopts[key] = value
+
+        # Execute the command
+        self.restapi.svc_run_command(cmd, cmdopts, cmdargs=None)
+        self.log('Clone (%s) created successfully.', self.name)
+        self.changed = True
+
+    def probe(self, clone_data):
+        params_mapping = (
+            ('ownershipgroup', clone_data.get('owner_name', '')),
+            ('ignoreuserfcmaps', clone_data.get('ignore_user_fc_maps', '')),
+            ('volumegroup', clone_data.get('volumegroup_name', '')),
+            ('iogrp', clone_data.get('IO_group_name', '')),
+            ('partition', clone_data.get('partition_name', '')),
+            ('preferrednode', clone_data.get('preferred_node_name', '')),
+            ('pool', clone_data.get('mdisk_grp_name', '')),
+            ('snapshot', clone_data.get('source_snapshot', '')),
+        )
+
+        props = dict((k, getattr(self, k)) for k, v in params_mapping if getattr(self, k) and getattr(self, k) != v)
+        # Check for type changes if volume is present but type is different
+        if self.OBJECT_TYPE == 'volume':
+            if clone_data.get('source_volume_name') != self.fromsourcevolumes:
+                self.module.fail_json(
+                    msg="Specified fromsourcevolumes does not match with existing clone's source volume."
+                )
+        else:
+            if 'pool' in props:
+                self.log("SGR pool in props")
+                # volumegroup's pool cannot be changed after creation
+                if self.check_volumes_in_pool(self.name, self.pool):
+                    del props['pool']
+
+        vol_type = clone_data.get('volume_type')
+        vg_type = clone_data.get('volume_group_type')
+        source_type = vol_type if vol_type is not None else vg_type
+
+        # Normalize empty ⇒ treat as "clone"
+        if source_type in ("", None):
+            source_type = "clone"
+
+        # Both conditions assign props['type'] = self.type
+        if (source_type == "clone" and self.type == "thinclone") or \
+           (source_type == "thinclone" and self.type == "clone"):
+            props["type"] = self.type
+        # If source type is clone, source_snapshot is not identifiable
+        if source_type == "clone":
+            if "source_snapshot" in props:
+                del props["source_snapshot"]
+        return props
+
+    def apply(self):
+        clone_data = self.get_existing_clone()
+        if clone_data:
+            self.log("Existing clone data: %s", clone_data)
+            # Volume already exists
+            if self.state == 'present':
+                modifications = self.probe(clone_data)
+                if modifications:
+                    self.log("Modifications detected: %s", modifications)
+                    self.module.fail_json(
+                        msg="Modifications of clone is not supported via this module, Please use ibm_svc_manage_volume or"
+                            " ibm_svc_manage_volumegroup for modifying volume or volumegroup clone/thinclone respectively.")
+                else:
+                    self.msg = "Clone %s already exists, no modification required." % self.name
+        else:
+            self.create_clone()
+            self.changed = True
+            self.msg = "Clone %s created." % self.name
+        self.module.exit_json(msg=self.msg, changed=self.changed)
+
+
+def main():
+    v = IBMSVClone()
+    try:
+        v.apply()
+    except Exception as e:
+        v.log("Exception in apply(): \n%s", format_exc())
+        v.module.fail_json(msg="Module failed. Error [%s]." % to_native(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/ibm_sv_manage_replication_policy.py
+++ b/plugins/modules/ibm_sv_manage_replication_policy.py
@@ -22,7 +22,7 @@ description:
 options:
     clustername:
         description:
-            - The hostname or management IP of the Storage Virtualize system.
+            - The hostname or management IP or Partition IP of the Storage Virtualize system.
         required: true
         type: str
     domain:
@@ -115,6 +115,7 @@ notes:
     - If both systems support HA snapshots, ha_snapshots will be enabled implicitly while creating replication policy with topology "2-site-ha".
     - Error Considerations
         - CMMVC1255E The command failed because the specified topology does not support highly-available snapshots
+    - This module supports logging in via partition IP.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ibm_sv_manage_snapshot.py
+++ b/plugins/modules/ibm_sv_manage_snapshot.py
@@ -23,7 +23,7 @@ description:
 options:
     clustername:
         description:
-            - The hostname or management IP of the Storage Virtualize system.
+            - The hostname or management IP or Partition IP of the Storage Virtualize system.
         required: true
         type: str
     domain:
@@ -129,6 +129,7 @@ notes:
       To create a new group of host accessible volumes from a snapshot,
       use M(ibm.storage_virtualize.ibm_svc_manage_volumegroup) module.
     - In case of restoring local snapshots present before establishing high availability (HA), HA sync will be stopped till the snapshots gets restored.
+    - This module supports logging in via partition IP.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ibm_sv_switch_replication_direction.py
+++ b/plugins/modules/ibm_sv_switch_replication_direction.py
@@ -21,7 +21,7 @@ description:
 options:
     clustername:
         description:
-            - The hostname or management IP of the Storage Virtualize system.
+            - The hostname or management IP or partition IP of the Storage Virtualize system.
         required: true
         type: str
     domain:
@@ -68,6 +68,7 @@ author:
     - Shilpi Jain(@Shilpi-J)
 notes:
     - This module supports C(check_mode).
+    - This module supports loggin via partitio IP.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ibm_svc_host.py
+++ b/plugins/modules/ibm_svc_host.py
@@ -35,7 +35,7 @@ options:
         type: str
     clustername:
         description:
-            - The hostname or management IP of the Storage Virtualize system.
+            - The hostname or management IP or Partition IP of the Storage Virtualize system.
         required: true
         type: str
     domain:
@@ -201,6 +201,9 @@ author:
 notes:
     - This module supports C(check_mode).
     - scsi option is deprecated from 8.5.0.0. Instead of scsi, use iscsi and fcscsi as the case may be.
+    - This module supports logging in via partition IP.
+    - Parameters not supported when logged in via partition IP are 'site', 'iogrp', 'partition', 'nopartition', 'draftpartition',
+      'site', 'nosite'.
 '''
 
 EXAMPLES = '''
@@ -476,7 +479,6 @@ class IBMSVChost(object):
                 ('partition', 'nopartition'),
                 ('draftpartition', 'nodraftpartition'),
                 ('draftpartition', 'partition'),
-                ('nqn', 'partition')
             )
             for param1, param2 in mutually_exclusive:
                 if getattr(self, param1) and getattr(self, param2):
@@ -670,9 +672,6 @@ class IBMSVChost(object):
                 self.iscsiname and self.fdminame) or (self.nqn and self.fdminame):
             self.module.fail_json(msg="You have to pass only one parameter among fcwwpn, nqn, iscsiname and fdminame to the module.")
 
-        if self.hostcluster and self.partition:
-            self.module.fail_json(msg='Mutually exclusive parameters: hostcluster and partition')
-
         if self.draftpartition:
             self.module.fail_json(msg='[draftpartition] is not a supported parameter while creating host')
         elif self.nodraftpartition:
@@ -790,8 +789,10 @@ class IBMSVChost(object):
         self.log("updating host '%s'", self.name)
         if 'hostcluster' in modify:
             self.addhostcluster()
+            modify.remove('hostcluster')
         elif 'nohostcluster' in modify:
             self.removehostcluster(host_data)
+            modify.remove('nohostcluster')
 
         cmd = 'chhost'
         cmdopts = {}

--- a/plugins/modules/ibm_svc_hostcluster.py
+++ b/plugins/modules/ibm_svc_hostcluster.py
@@ -31,7 +31,7 @@ options:
         type: str
     clustername:
         description:
-            - The hostname or management IP of the Storage Virtualize system.
+            - The hostname or management IP or Partition IP of the Storage Virtualize system.
         required: true
         type: str
     domain:
@@ -110,6 +110,9 @@ author:
     - Sandip Gulab Rajbanshi (@Sandip-Rajbanshi)
 notes:
     - This module supports C(check_mode).
+    - This module supports logging in via partition IP.
+    - Parameters not supported when logged in via partition IP are 'ownershipgroup', 'noownershipgroup', 'removeallhosts', 'site',
+      'removemappings'.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ibm_svc_info.py
+++ b/plugins/modules/ibm_svc_info.py
@@ -32,7 +32,7 @@ author:
 options:
   clustername:
     description:
-    - The hostname or management IP of the
+    - The hostname or management IP or Partition IP of the
       Storage Virtualize system.
     type: str
     required: true
@@ -189,6 +189,7 @@ notes:
     - This module supports C(check_mode).
     - If both I(gather_subset) and I(command_list) are not specified, ibm_svc_info will list information about I(default) objects.
     - I(lsroute) and I(lsarraylba) commands are not covered.
+    - This module supports logging in via partition IP.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ibm_svc_manage_volume.py
+++ b/plugins/modules/ibm_svc_manage_volume.py
@@ -31,7 +31,7 @@ options:
     type: str
   clustername:
     description:
-      - The hostname or management IP of the Storage Virtualize system.
+      - The hostname or management IP or Partition IP of the Storage Virtualize system.
     required: true
     type: str
   domain:
@@ -185,6 +185,26 @@ options:
     choices: [32, 64, 128, 256]
     type: int
     version_added: '3.0.0'
+  preferrednode:
+    description:
+      - Specifies the preferred node name that is used to access the volume.
+      - When not specified, the system selects the preferred node automatically.
+    type: str
+    version_added: '3.2.0'
+  cache:
+    description:
+      - Specifies the caching options for the volume.
+      - When not specified, the default value is 'readwrite'.
+    type: str
+    choices: [readwrite, readonly, none]
+    version_added: '3.2.0'
+  autoexpand:
+    description:
+      - Specifies whether thin-provisioned volume copies automatically expand their real capacities.
+      - If specified as off, works as `noautoexpand`.
+    type: str
+    choices: ['on', 'off']
+    version_added: '3.2.0'
 author:
     - Sreshtant Bohidar(@Sreshtant-Bohidar)
     - Rahul Pawar(@rahul-p)
@@ -194,6 +214,8 @@ notes:
     - For unmap parameter, the option remotecopy_relationships has been deprecated from 8.7.1.0 onwards.
     - CMMVC9855E The command failed because one of more of the specified volumes does not exist.
       This error occurs when the user-provided volume(s) do not exist.
+    - This module supports logging in via partition IP.
+    - To create a clone or thinclone of a Volume, please refer to ibm_sv_manage_clone module.
 '''
 
 EXAMPLES = r'''
@@ -424,7 +446,10 @@ class IBMSVCvolume(object):
                 type=dict(type='str', required=False, choices=['clone', 'thinclone']),
                 fromsourcevolume=dict(type='str', required=False),
                 allow_hs=dict(type='bool', default=False),
-                grainsize=dict(type='int', required=False, choices=[32, 64, 128, 256])
+                grainsize=dict(type='int', required=False, choices=[32, 64, 128, 256]),
+                preferrednode=dict(type='str', required=False),
+                cache=dict(type='str', required=False, choices=['readwrite', 'readonly', 'none']),
+                autoexpand=dict(type='str', required=False, choices=['on', 'off'])
             )
         )
 
@@ -459,6 +484,9 @@ class IBMSVCvolume(object):
         self.fromsourcevolume = self.module.params['fromsourcevolume']
         self.unmap = self.module.params['unmap']
         self.grainsize = self.module.params['grainsize']
+        self.preferrednode = self.module.params['preferrednode']
+        self.cache = self.module.params['cache']
+        self.autoexpand = self.module.params['autoexpand']
 
         # internal variable
         self.changed = False
@@ -477,25 +505,24 @@ class IBMSVCvolume(object):
     # assemble iogrp
     def assemble_iogrp(self):
         if self.iogrp:
-            temp = []
-            invalid = []
-            active_iogrp = []
-            existing_iogrp = []
-            if self.iogrp:
-                existing_iogrp = [item.strip() for item in self.iogrp.split(',') if item]
-            uni_exi_iogrp = set(existing_iogrp)
-            if len(existing_iogrp) != len(uni_exi_iogrp):
+            input_iogrps = [item.strip() for item in self.iogrp.split(',') if item]
+            self.len_input_iogrps = len(input_iogrps)
+            if self.len_input_iogrps != len(set(input_iogrps)):
                 self.module.fail_json(msg='Duplicate iogrp detected.')
-            active_iogrp = [item['name'] for item in self.restapi.svc_obj_info('lsiogrp', None, None) if int(item['node_count']) > 0]
-            for item in existing_iogrp:
-                item = item.strip()
-                if item not in active_iogrp:
-                    invalid.append(item)
+
+            self.active_iogrp = [item['name'] for item in self.restapi.svc_obj_info('lsiogrp', None, None) if int(item['node_count']) > 0]
+
+            valid_iogrp = []
+            invalid_iogrp = []
+            for item in input_iogrps:
+                if item not in self.active_iogrp:
+                    invalid_iogrp.append(item)
                 else:
-                    temp.append(item)
-            if invalid:
-                self.module.fail_json(msg='Empty or non-existing iogrp detected: {0}'.format(invalid))
-            self.iogrp = temp
+                    valid_iogrp.append(item)
+            if invalid_iogrp:
+                self.module.fail_json(msg='Empty or non-existing iogrp detected: {0}'.format(invalid_iogrp))
+
+            self.iogrp = valid_iogrp
 
     # Validate mandatory parameters of the module
     def mandatory_parameter_validation(self):
@@ -515,7 +542,7 @@ class IBMSVCvolume(object):
     def volume_deletion_parameter_validation(self):
         invalids = ('pool', 'size', 'iogrp', 'buffersize', 'volumegroup', 'novolumegroup',
                     'thin', 'compressed', 'deduplicated', 'old_name', 'enable_cloud_snapshot',
-                    'cloud_account_name', 'allow_hs', 'type', 'fromsourcevolume', 'warning', 'grainsize')
+                    'cloud_account_name', 'allow_hs', 'type', 'fromsourcevolume', 'warning', 'grainsize', 'preferrednode', 'cache', 'autoexpand')
 
         invalid_params = ', '.join((param for param in invalids if getattr(self, param)))
 
@@ -544,8 +571,17 @@ class IBMSVCvolume(object):
         if self.grainsize and not self.thin:
             self.module.fail_json(msg='Parameter [grainsize] is invalid without [thin]')
 
+        if self.deduplicated and not (self.thin or self.compressed):
+            self.module.fail_json(msg='Parameter [deduplicated] is invalid without [thin] or [compressed]')
+
+        if self.preferrednode and (not self.iogrp or self.len_input_iogrps != 1):
+            self.module.fail_json(msg='Parameter [preferrednode] is only valid with a single iogrp.')
+
+        if self.autoexpand and (not self.thin and not self.compressed):
+            self.module.fail_json(msg='Parameter [autoexpand] is invalid without [thin]')
+
         missing = []
-        if self.type and self.fromsourcevolume:
+        if self.type:
             if not self.pool:
                 missing = ['pool']
             if self.size:
@@ -580,7 +616,10 @@ class IBMSVCvolume(object):
             "type": self.type,
             "fromsourcevolume": self.fromsourcevolume,
             "warning": self.warning,
-            "grainsize": self.grainsize
+            "grainsize": self.grainsize,
+            "preferrednode": self.preferrednode,
+            "cache": self.cache,
+            "autoexpand": self.autoexpand
         }
         parameters_exists = [parameter for parameter, value in parameters.items() if value]
         if parameters_exists:
@@ -709,6 +748,12 @@ class IBMSVCvolume(object):
             cmdopts['name'] = self.name
         if self.warning:
             cmdopts['warning'] = str(self.warning) + '%'
+        if self.preferrednode:
+            cmdopts['preferrednode'] = self.preferrednode
+        if self.cache:
+            cmdopts['cache'] = self.cache
+        if self.autoexpand == 'off':
+            cmdopts['noautoexpand'] = True
         if self.type:
             cmdopts['type'] = self.type
             snapshot_id = self.create_transient_snapshot()
@@ -754,6 +799,7 @@ class IBMSVCvolume(object):
     # function to probe an existing volume
     def probe_volume(self, data):
         props = {}
+
         # check for changes in iogrp
         if self.iogrp:
             input_iogrp = set(self.iogrp)
@@ -803,33 +849,17 @@ class IBMSVCvolume(object):
                 props['novolumegroup'] = {
                     'status': True
                 }
-        # check for change in -thin parameter
-        if self.thin is not None:
-            if self.thin is True:
-                # a standard volume or a compressed volume
-                if (data[0]['capacity'] == data[1]['real_capacity']) or (data[1]['compressed_copy'] == 'yes'):
-                    props['thin'] = {
-                        'status': True
-                    }
-            else:
-                if (data[0]['capacity'] != data[1]['real_capacity']) or (data[1]['compressed_copy'] == 'no'):
-                    props['thin'] = {
-                        'status': True
-                    }
-        # check for change in -compressed parameter
-        if self.compressed is True:
-            # not a compressed volume
-            if data[1]['compressed_copy'] == 'no':
-                props['compressed'] = {
-                    'status': True
-                }
-        # check for change in -deduplicated parameter
-        if self.deduplicated is True:
-            # not a deduplicated volume
-            if data[1]['deduplicated_copy'] == 'no':
-                props['deduplicated'] = {
-                    'status': True
-                }
+
+        # check for change in thin, compressed and deduplicated
+        for attr, field in (('thin', 'se_copy'),
+                            ('compressed', 'compressed_copy'),
+                            ('deduplicated', 'deduplicated_copy')):
+            val = getattr(self, attr)
+            if val is not None:
+                current = str(data[1].get(field)).lower() == 'yes'
+                if bool(val) != current:
+                    props[attr] = {'status': True}
+
         # check for change in pool
         if self.pool:
             if self.pool != data[0]['mdisk_grp_name']:
@@ -861,6 +891,15 @@ class IBMSVCvolume(object):
         if self.grainsize:
             if self.grainsize != int(data[1].get('grainsize') or 0):
                 props['grainsize'] = {'status': True}
+
+        if self.preferrednode and self.preferrednode != data[0].get('preferred_node_name'):
+            props['preferrednode'] = self.preferrednode
+
+        if self.cache and self.cache != data[0].get('cache'):
+            props['cache'] = self.cache
+
+        if self.autoexpand and self.autoexpand != data[1].get('autoexpand'):
+            props['autoexpand'] = self.autoexpand
 
         self.log("Properties to be changed: %s", props)
         return props
@@ -944,13 +983,13 @@ class IBMSVCvolume(object):
     # function to update an existing volume
     def update_volume(self, modify):
         # raise error for unsupported parameter(s)
-        unsupported_parameters = ['pool', 'thin', 'compressed', 'deduplicated', 'fromsourcevolume', 'grainsize']
+        unsupported_parameters = ['pool', 'thin', 'compressed', 'deduplicated', 'fromsourcevolume', 'grainsize', 'preferrednode']
         unsupported_exists = [param for param in unsupported_parameters if param in modify]
         if unsupported_exists:
             self.module.fail_json(msg=f"Update not supported for parameter(s): {', '.join(unsupported_exists)}")
 
-        invalid_params = ['warning', 'cloud_backup', 'volumegroup', 'novolumegroup', 'size']
-        mutually_exclusive_params = [param for param in invalid_params if param in modify]
+        invalid_together = ['warning', 'cloud_backup', 'volumegroup', 'novolumegroup', 'size', 'cache', 'autoexpand']
+        mutually_exclusive_params = [param for param in invalid_together if param in modify]
 
         # If any 2 conflicting parameters are passed, return error
         if len(mutually_exclusive_params) > 1:
@@ -997,6 +1036,11 @@ class IBMSVCvolume(object):
                         cmdopts['unit'] = self.unit
                 else:
                     self.expand_volume(modify['size']['expand'])
+
+        if 'cache' in modify:
+            cmdopts['cache'] = modify['cache']
+        if 'autoexpand' in modify:
+            cmdopts['autoexpand'] = modify['autoexpand']
 
         if cmdopts:
             self.restapi.svc_run_command(

--- a/plugins/modules/ibm_svc_manage_volumegroup.py
+++ b/plugins/modules/ibm_svc_manage_volumegroup.py
@@ -33,7 +33,7 @@ options:
         type: str
     clustername:
         description:
-            - The hostname or management IP of the Storage Virtualize system.
+            - The hostname or management IP or Partition IP of the Storage Virtualize system.
         required: true
         type: str
     domain:
@@ -239,6 +239,7 @@ notes:
     - This module supports C(check_mode).
     - Safeguarded policy and snapshot policy cannot be used at the same time.
       Therefore, the parameters I(snapshotpolicy) and I(safeguardpolicyname) are mutually exclusive.
+    - This module supports logging in via partition IP.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ibm_svc_vol_map.py
+++ b/plugins/modules/ibm_svc_vol_map.py
@@ -47,7 +47,7 @@ options:
     type: str
   clustername:
     description:
-      - The hostname or management IP of the Storage Virtualize system.
+      - The hostname or management IP or Partition IP of the Storage Virtualize system.
     type: str
     required: true
   domain:
@@ -84,6 +84,7 @@ author:
     - Peng Wang(@wangpww)
 notes:
     - This module supports C(check_mode).
+    - This module supports logging in via partition IP.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ibm_svcinfo_command.py
+++ b/plugins/modules/ibm_svcinfo_command.py
@@ -39,7 +39,7 @@ options:
     type: str
   clustername:
     description:
-    - The hostname or management IP of the
+    - The hostname or management IP or Partition IP of the
       storage Virtualize system.
     type: str
     required: true
@@ -61,6 +61,8 @@ options:
     description:
     - Path of debug log file.
     type: str
+notes:
+  - This module supports logging in via partition IP.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ibm_svctask_command.py
+++ b/plugins/modules/ibm_svctask_command.py
@@ -45,7 +45,7 @@ options:
     type: str
   clustername:
     description:
-    - The hostname or management IP of the Storage Virtualize system.
+    - The hostname or management IP or Partition IP of the Storage Virtualize system.
     type: str
     required: true
   domain:
@@ -66,6 +66,8 @@ options:
     description:
     - Path of debug log file.
     type: str
+notes:
+  - This module supports logging in via partition IP.
 '''
 
 EXAMPLES = '''

--- a/tests/unit/plugins/modules/test_ibm_sv_manage_clone.py
+++ b/tests/unit/plugins/modules/test_ibm_sv_manage_clone.py
@@ -1,0 +1,634 @@
+# Copyright (C) 2023 IBM CORPORATION
+# Author(s):  Sandip Gulab Rajbanshi <sandip.rajbanshi@ibm.com>
+#
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+""" unit tests IBM Storage Virtualize Ansible module: ibm_sv_manage_clone """
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import unittest
+import pytest
+import json
+from mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible_collections.ibm.storage_virtualize.plugins.module_utils.ibm_svc_utils import IBMSVCRestApi
+from ansible_collections.ibm.storage_virtualize.plugins.modules.ibm_sv_manage_clone import IBMSVClone
+import contextlib
+
+
+@contextlib.contextmanager
+def set_module_args(args):
+    """
+    Context manager that sets module arguments for AnsibleModule
+    """
+    if '_ansible_remote_tmp' not in args:
+        args['_ansible_remote_tmp'] = '/tmp'
+    if '_ansible_keep_remote_files' not in args:
+        args['_ansible_keep_remote_files'] = False
+
+    try:
+        from ansible.module_utils.testing import patch_module_args
+        with patch_module_args(args):
+            yield
+    except ImportError:
+        from ansible.module_utils import basic
+        serialized_args = to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': args}))
+        with patch.object(basic, '_ANSIBLE_ARGS', serialized_args):
+            yield
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the
+    test case """
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the
+    test case """
+    pass
+
+
+def exit_json(*args, **kwargs):  # pylint: disable=unused-argument
+    """function to patch over exit_json; package return data into an
+    exception """
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    """function to patch over fail_json; package return data into an
+    exception """
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class TestIBMSVClone(unittest.TestCase):
+    """ Test class for ibm_sv_manage_drive module """
+    """
+    Group of related Unit Tests
+    """
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def setUp(self, connect):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+        self.restapi = IBMSVCRestApi(self.mock_module_helper, '1.2.3.4',
+                                     'domain.ibm.com', 'username', 'password',
+                                     False, 'test.log', '')
+
+    def test_module_with_blank_values(self):
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': ''
+        }):
+            with pytest.raises(AnsibleFailJson) as exc:
+                IBMSVClone()
+            self.assertTrue(exc.value.args[0]['failed'])
+
+    def test_module_with_invalid_params_1(self):
+        '''
+        partition, ownershipgroup, ignoreuserfcmaps parameters are invalid in case of volume clone
+        '''
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'clone_name_01',
+            'state': 'present',
+            'type': 'clone',
+            'snapshot': 'snapshot_id_1234',
+            'pool': 'pool1',
+            'fromsourcevolumes': "test_vol_3",
+            'partition': 'partition1',
+            'ownershipgroup': 'group1',
+            'ignoreuserfcmaps': 'yes'
+        }):
+            with pytest.raises(AnsibleFailJson) as exc:
+                clone = IBMSVClone()
+                clone.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+            self.assertEqual(exc.value.args[0]['msg'],
+                             "Volume clone operation does not support the parameter(s): partition, "
+                             "ownershipgroup, ignoreuserfcmaps")
+
+    def test_module_with_invalid_params_2(self):
+        '''
+        volumegroup, preferrednode parameters are invalid in case of volumegroup clone
+        '''
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'clone_name_01',
+            'state': 'present',
+            'type': 'clone',
+            'snapshot': 'snapshot_id_1234',
+            'pool': 'pool1',
+            'volumegroup': 'vg1',
+            'preferrednode': "node1"
+        }):
+            with pytest.raises(AnsibleFailJson) as exc:
+                clone = IBMSVClone()
+                clone.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+            self.assertEqual(exc.value.args[0]['msg'],
+                             "Volumegroup clone operation does not support the parameter(s): volumegroup, preferrednode")
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_parent_uid_or_source_grp_from_snapshot')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_existing_clone')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_clone_volume(self, svc_authorize_mock,
+                                 get_existing_clone_mock,
+                                 get_parent_uid_or_source_grp_from_snapshot_mock,
+                                 svc_run_command_mock):
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'clone_name_01',
+            'state': 'present',
+            'type': 'clone',
+            'snapshot': 'snapshot_id_1234',
+            'pool': 'pool1',
+            'fromsourcevolumes': "test_vol_3"
+        }):
+            get_existing_clone_mock.return_value = {}
+            get_parent_uid_or_source_grp_from_snapshot_mock.return_value = (None, "111")
+            svc_run_command_mock.return_value = ""
+            clone = IBMSVClone()
+            with pytest.raises(AnsibleExitJson) as exc:
+                clone.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+            args, kwargs = svc_run_command_mock.call_args
+            self.assertEqual(args[0], 'mkvolume')
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_existing_clone')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_clone_volume_idempotency(self, svc_authorize_mock,
+                                             get_existing_clone_mock):
+        get_existing_clone_mock.return_value = {
+            "id": "61", "name": "clone_name_01", "IO_group_id": "0",
+            "IO_group_name": "io_grp0", "status": "online", "mdisk_grp_id": "0",
+            "mdisk_grp_name": "pool1", "capacity": "1.00GB", "type": "striped",
+            "vdisk_UID": "6005076812B7018CB0000000000001B9", "fc_map_count": "0",
+            "sync_rate": "50", "copy_count": "1", "se_copy_count": "0", "preferred_node_id": "1",
+            "fast_write_state": "empty", "cache": "readwrite", "udid": "",
+            "parent_mdisk_grp_id": "0", "parent_mdisk_grp_name": "pool1",
+            "owner_type": "none", "owner_id": "", "owner_name": "", "encrypt": "no",
+            "volume_id": "61", "volume_name": "nclone_name_01", "function": "",
+            "preferred_node_name": "node1", "safeguarded_expiration_time": "",
+            "safeguarded_backup_count": "0", "is_snapshot": "no", "snapshot_count": "0",
+            "volume_type": "clone", "source_volume_id": "15", "source_volume_name": "test_vol_3",
+            "source_snapshot": "snapshot_id_1234", "source_snapshot_timestamp": "",
+            "protection_provisioned_capacity": "0.00MB"}
+
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'clone_name_01',
+            'state': 'present',
+            'type': 'clone',
+            'snapshot': 'snapshot_id_1234',
+            'pool': 'pool1',
+            'fromsourcevolumes': "test_vol_3"
+        }):
+            with pytest.raises(AnsibleExitJson) as exc:
+                clone = IBMSVClone()
+                clone.apply()
+            self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_existing_clone')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_unsupported_remove_clone(self, svc_authorize_mock,
+                                      get_existing_clone_mock):
+        get_existing_clone_mock.return_value = {
+            "id": "61", "name": "clone_name_01", "IO_group_id": "0",
+            "IO_group_name": "io_grp0", "status": "online", "mdisk_grp_id": "0",
+            "mdisk_grp_name": "pool1", "capacity": "1.00GB", "type": "striped",
+            "vdisk_UID": "6005076812B7018CB0000000000001B9", "fc_map_count": "0",
+            "sync_rate": "50", "copy_count": "1", "se_copy_count": "0", "preferred_node_id": "1",
+            "fast_write_state": "empty", "cache": "readwrite", "udid": "",
+            "parent_mdisk_grp_id": "0", "parent_mdisk_grp_name": "pool1",
+            "owner_type": "none", "owner_id": "", "owner_name": "", "encrypt": "no",
+            "volume_id": "61", "volume_name": "nclone_name_01", "function": "",
+            "preferred_node_name": "node1", "safeguarded_expiration_time": "",
+            "safeguarded_backup_count": "0", "is_snapshot": "no", "snapshot_count": "0",
+            "volume_type": "clone", "source_volume_id": "15", "source_volume_name": "test_vol_3",
+            "source_snapshot": "snapshot_id_1234", "source_snapshot_timestamp": "",
+            "protection_provisioned_capacity": "0.00MB"}
+
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'clone_name_01',
+            'state': 'absent',
+            'type': 'clone',
+            'snapshot': 'snapshot_id_1234',
+            'pool': 'pool1'
+        }):
+            with pytest.raises(AnsibleFailJson) as exc:
+                clone = IBMSVClone()
+                clone.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+            self.assertEqual(exc.value.args[0]['msg'],
+                             "Removal of clone is not supported via this module. Please use ibm_svc_manage_volume or "
+                             "ibm_svc_manage_volumegroup for removing volume or volumegroup clone/thinclone respectively.")
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_existing_clone')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_unsupported_update_volume_thinclone_to_clone(self, svc_authorize_mock,
+                                                          get_existing_clone_mock):
+        get_existing_clone_mock.return_value = {
+            "id": "61", "name": "clone_name_01", "IO_group_id": "0",
+            "IO_group_name": "io_grp0", "status": "online", "mdisk_grp_id": "0",
+            "mdisk_grp_name": "site1pool1", "capacity": "1.00GB", "type": "striped",
+            "vdisk_UID": "6005076812B7018CB0000000000001B9", "fc_map_count": "0",
+            "sync_rate": "50", "copy_count": "1", "se_copy_count": "0", "preferred_node_id": "1",
+            "fast_write_state": "empty", "cache": "readwrite", "udid": "",
+            "parent_mdisk_grp_id": "0", "parent_mdisk_grp_name": "site1pool1",
+            "owner_type": "none", "owner_id": "", "owner_name": "", "encrypt": "no",
+            "volume_id": "61", "volume_name": "nclone_name_01", "function": "",
+            "preferred_node_name": "node1", "safeguarded_expiration_time": "",
+            "safeguarded_backup_count": "0", "is_snapshot": "no", "snapshot_count": "0",
+            "volume_type": "thinclone", "source_volume_id": "15", "source_volume_name": "test_vol_1",
+            "source_snapshot": "snapshot_id_1234", "source_snapshot_timestamp": "",
+            "protection_provisioned_capacity": "0.00MB"}
+
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'clone_name_01',
+            'state': 'present',
+            'type': 'clone',
+            'snapshot': 'snapshot_id_1234',
+            'fromsourcevolumes': "test_vol_1"
+        }):
+            with pytest.raises(AnsibleFailJson) as exc:
+                clone = IBMSVClone()
+                clone.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+            self.assertEqual(exc.value.args[0]['msg'],
+                             "Modifications of clone is not supported via this module, Please use ibm_svc_manage_volume or "
+                             "ibm_svc_manage_volumegroup for modifying volume or volumegroup clone/thinclone respectively.")
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_existing_clone')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_unsupported_update_volume_source_snapshot(self, svc_authorize_mock,
+                                                       get_existing_clone_mock):
+        get_existing_clone_mock.return_value = {
+            "id": "61", "name": "clone_name_01", "IO_group_id": "0",
+            "IO_group_name": "io_grp0", "status": "online", "mdisk_grp_id": "0",
+            "mdisk_grp_name": "site1pool1", "capacity": "1.00GB", "type": "striped",
+            "vdisk_UID": "6005076812B7018CB0000000000001B9", "fc_map_count": "0",
+            "sync_rate": "50", "copy_count": "1", "se_copy_count": "0", "preferred_node_id": "1",
+            "fast_write_state": "empty", "cache": "readwrite", "udid": "",
+            "parent_mdisk_grp_id": "0", "parent_mdisk_grp_name": "site1pool1",
+            "owner_type": "none", "owner_id": "", "owner_name": "", "encrypt": "no",
+            "volume_id": "61", "volume_name": "nclone_name_01", "function": "",
+            "preferred_node_name": "node1", "safeguarded_expiration_time": "",
+            "safeguarded_backup_count": "0", "is_snapshot": "no", "snapshot_count": "0",
+            "volume_type": "thinclone", "source_volume_id": "15", "source_volume_name": "test_vol_1",
+            "source_snapshot": "snapshot_id_1235", "source_snapshot_timestamp": "",
+            "protection_provisioned_capacity": "0.00MB"}
+
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'clone_name_01',
+            'state': 'present',
+            'type': 'thinclone',
+            'snapshot': 'snapshot_id_1234',
+            'fromsourcevolumes': "test_vol_1"
+        }):
+            with pytest.raises(AnsibleFailJson) as exc:
+                clone = IBMSVClone()
+                clone.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+            self.assertEqual(exc.value.args[0]['msg'],
+                             "Modifications of clone is not supported via this module, Please use ibm_svc_manage_volume or "
+                             "ibm_svc_manage_volumegroup for modifying volume or volumegroup clone/thinclone respectively.")
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_parent_uid_or_source_grp_from_snapshot')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_existing_clone')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_clone_volumegroup(self, svc_authorize_mock,
+                                      get_existing_clone_mock,
+                                      get_parent_uid_or_source_grp_from_snapshot_mock,
+                                      svc_run_command_mock):
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'clone_name_01',
+            'state': 'present',
+            'type': 'clone',
+            'snapshot': 'snapshot_id_1234',
+            'pool': 'pool1'
+        }):
+            get_existing_clone_mock.return_value = {}
+            get_parent_uid_or_source_grp_from_snapshot_mock.return_value = ('vg1', None)
+            svc_run_command_mock.return_value = ""
+            clone = IBMSVClone()
+            with pytest.raises(AnsibleExitJson) as exc:
+                clone.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+            args, kwargs = svc_run_command_mock.call_args
+            self.assertEqual(args[0], 'mkvolumegroup')
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.check_volumes_in_pool')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_existing_clone')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_clone_volumegroup_idempotency(self, svc_authorize_mock,
+                                                  get_existing_clone_mock,
+                                                  check_volumes_in_pool_mock):
+        get_existing_clone_mock.return_value = {
+            "id": "1", "name": "clone_name_01", "volume_count": "4",
+            "backup_status": "off", "last_backup_time": "", "owner_id": "",
+            "owner_name": "", "safeguarded_policy_id": "", "safeguarded_policy_name": "",
+            "safeguarded_policy_start_time": "", "replication_policy_id": "",
+            "replication_policy_name": "", "ha_replication_policy_id": "0",
+            "ha_replication_policy_name": "ha-policy-0", "volume_group_type": "clone",
+            "uid": "99", "source_volume_group_id": "", "source_volume_group_name": "",
+            "parent_uid": "", "source_snapshot_id": "", "source_snapshot": "snapshot_id_1234",
+            "snapshot_count": "0", "protection_provisioned_capacity": "4.00GB",
+            "protection_written_capacity": "3.00MB", "snapshot_policy_id": "",
+            "snapshot_policy_name": "", "snapshot_policy_uuid": "26CDECD0-5625-0000-5002-000000000000",
+            "safeguarded_snapshot_count": "0", "ignore_user_flash_copy_maps": "no",
+            "partition_id": "0", "partition_name": "ptn_test", "restore_in_progress": "no",
+            "owner_type": "none", "draft_partition_id": "", "draft_partition_name": "",
+            "last_restore_time": "", "dr_replicated": "no", "partition_default": "no",
+            "host_provisioned_capacity": "4.00GB", "anomaly_sequence_number": "",
+            "uuid": "9C16DE02-1F11-528A-B978-805E906C5B3B"}
+
+        volume_list = [
+            {"id": "61", "name": "clone_vol_01", "IO_group_id": "0",
+             "IO_group_name": "io_grp0", "status": "online", "mdisk_grp_id": "0",
+             "mdisk_grp_name": "pool1", "capacity": "1.00GB", "type": "striped",
+             "volume_type": "clone", "source_volume_id": "15", "source_volume_name": "test_vol_1",
+             "source_snapshot": "snapshot_id_1234"},
+            {"id": "62", "name": "clone_vol_02", "IO_group_id": "0",
+             "IO_group_name": "io_grp0", "status": "online", "mdisk_grp_id": "0",
+             "mdisk_grp_name": "pool1", "capacity": "1.00GB", "type": "striped",
+             "volume_type": "clone", "source_volume_id": "15", "source_volume_name": "test_vol_2",
+             "source_snapshot": "snapshot_id_1234"},
+            {"id": "63", "name": "clone_vol_03", "IO_group_id": "0",
+             "IO_group_name": "io_grp0", "status": "online", "mdisk_grp_id": "0",
+             "mdisk_grp_name": "pool1", "capacity": "1.00GB", "type": "striped",
+             "volume_type": "clone", "source_volume_id": "15", "source_volume_name": "test_vol_3",
+             "source_snapshot": "snapshot_id_1234"},
+            {"id": "64", "name": "clone_vol_04", "IO_group_id": "0",
+             "IO_group_name": "io_grp0", "status": "online", "mdisk_grp_id": "0",
+             "mdisk_grp_name": "pool1", "capacity": "1.00GB", "type": "striped",
+             "volume_type": "clone", "source_volume_id": "15", "source_volume_name": "test_vol_4",
+             "source_snapshot": "snapshot_id_1234"}]
+
+        check_volumes_in_pool_mock.return_value = volume_list
+
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'clone_name_01',
+            'state': 'present',
+            'type': 'clone',
+            'snapshot': 'snapshot_id_1234',
+            'pool': 'pool1'
+        }):
+            with pytest.raises(AnsibleExitJson) as exc:
+                clone = IBMSVClone()
+                clone.apply()
+            self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_parent_uid_or_source_grp_from_snapshot')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_existing_clone')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_clone_volume_vector(self, svc_authorize_mock,
+                                        get_existing_clone_mock,
+                                        get_parent_uid_or_source_grp_from_snapshot_mock,
+                                        svc_run_command_mock):
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'clone_name_01',
+            'state': 'present',
+            'type': 'clone',
+            'snapshot': 'snapshot_id_1234',
+            'pool': 'pool1',
+            'fromsourcevolumes': "test_vol_1:test_vol_2"
+        }):
+            get_existing_clone_mock.return_value = {}
+            get_parent_uid_or_source_grp_from_snapshot_mock.return_value = ('vg1', None)
+            svc_run_command_mock.return_value = ""
+            clone = IBMSVClone()
+            with pytest.raises(AnsibleExitJson) as exc:
+                clone.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+            args, kwargs = svc_run_command_mock.call_args
+            self.assertEqual(args[0], 'mkvolumegroup')
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_existing_clone')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_clone_volume_vector_idempotency(self, svc_authorize_mock,
+                                                    get_existing_clone_mock):
+        get_existing_clone_mock.return_value = {
+            "id": "1", "name": "clone_name_01", "volume_count": "2",
+            "backup_status": "off", "last_backup_time": "", "owner_id": "",
+            "owner_name": "", "safeguarded_policy_id": "", "safeguarded_policy_name": "",
+            "safeguarded_policy_start_time": "", "replication_policy_id": "",
+            "replication_policy_name": "", "ha_replication_policy_id": "0",
+            "ha_replication_policy_name": "ha-policy-0", "volume_group_type": "clone",
+            "uid": "99", "source_volume_group_id": "", "source_volume_group_name": "",
+            "parent_uid": "", "source_snapshot_id": "", "source_snapshot": "snapshot_id_1234",
+            "snapshot_count": "0", "protection_provisioned_capacity": "4.00GB",
+            "protection_written_capacity": "3.00MB", "snapshot_policy_id": "",
+            "snapshot_policy_name": "", "snapshot_policy_uuid": "26CDECD0-5625-0000-5002-000000000000",
+            "safeguarded_snapshot_count": "0", "ignore_user_flash_copy_maps": "no",
+            "partition_id": "0", "partition_name": "ptn_test", "restore_in_progress": "no",
+            "owner_type": "none", "draft_partition_id": "", "draft_partition_name": "",
+            "last_restore_time": "", "dr_replicated": "no", "partition_default": "no",
+            "host_provisioned_capacity": "4.00GB", "anomaly_sequence_number": "",
+            "uuid": "9C16DE02-1F11-528A-B978-805E906C5B3B"}
+
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'clone_name_01',
+            'state': 'present',
+            'type': 'clone',
+            'snapshot': 'snapshot_id_1234',
+            'fromsourcevolumes': "test_vol_1:test_vol_2"
+        }):
+            with pytest.raises(AnsibleExitJson) as exc:
+                clone = IBMSVClone()
+                clone.apply()
+            self.assertFalse(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_existing_clone')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_unsupported_update_volumegroup_thinclone_to_clone(self, svc_authorize_mock,
+                                                               get_existing_clone_mock):
+        get_existing_clone_mock.return_value = {
+            "id": "1", "name": "clone_name_01", "volume_count": "2",
+            "backup_status": "off", "last_backup_time": "", "owner_id": "",
+            "owner_name": "", "safeguarded_policy_id": "", "safeguarded_policy_name": "",
+            "safeguarded_policy_start_time": "", "replication_policy_id": "",
+            "replication_policy_name": "", "ha_replication_policy_id": "0",
+            "ha_replication_policy_name": "ha-policy-0", "volume_group_type": "thinclone",
+            "uid": "99", "source_volume_group_id": "", "source_volume_group_name": "",
+            "parent_uid": "", "source_snapshot_id": "", "source_snapshot": "snapshot_id_1234",
+            "snapshot_count": "0", "protection_provisioned_capacity": "4.00GB",
+            "protection_written_capacity": "3.00MB", "snapshot_policy_id": "",
+            "snapshot_policy_name": "", "snapshot_policy_uuid": "26CDECD0-5625-0000-5002-000000000000",
+            "safeguarded_snapshot_count": "0", "ignore_user_flash_copy_maps": "no",
+            "partition_id": "0", "partition_name": "ptn_test", "restore_in_progress": "no",
+            "owner_type": "none", "draft_partition_id": "", "draft_partition_name": "",
+            "last_restore_time": "", "dr_replicated": "no", "partition_default": "no",
+            "host_provisioned_capacity": "4.00GB", "anomaly_sequence_number": "",
+            "uuid": "9C16DE02-1F11-528A-B978-805E906C5B3B"}
+
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'clone_name_01',
+            'state': 'present',
+            'type': 'clone',
+            'snapshot': 'snapshot_id_1234',
+        }):
+            with pytest.raises(AnsibleFailJson) as exc:
+                clone = IBMSVClone()
+                clone.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+            self.assertEqual(exc.value.args[0]['msg'],
+                             "Modifications of clone is not supported via this module, Please use ibm_svc_manage_volume or "
+                             "ibm_svc_manage_volumegroup for modifying volume or volumegroup clone/thinclone respectively.")
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
+           'ibm_sv_manage_clone.IBMSVClone.get_existing_clone')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_unsupported_update_volumegroup_pool(self, svc_authorize_mock,
+                                                 get_existing_clone_mock,
+                                                 svc_obj_info_mock):
+        get_existing_clone_mock.return_value = {
+            "id": "1", "name": "clone_name_01", "volume_count": "2",
+            "backup_status": "off", "last_backup_time": "", "owner_id": "",
+            "owner_name": "", "safeguarded_policy_id": "", "safeguarded_policy_name": "",
+            "safeguarded_policy_start_time": "", "replication_policy_id": "",
+            "replication_policy_name": "", "ha_replication_policy_id": "0",
+            "ha_replication_policy_name": "ha-policy-0", "volume_group_type": "thinclone",
+            "uid": "99", "source_volume_group_id": "", "source_volume_group_name": "",
+            "parent_uid": "", "source_snapshot_id": "", "source_snapshot": "snapshot_id_1234",
+            "snapshot_count": "0", "protection_provisioned_capacity": "4.00GB",
+            "protection_written_capacity": "3.00MB", "snapshot_policy_id": "",
+            "snapshot_policy_name": "", "snapshot_policy_uuid": "26CDECD0-5625-0000-5002-000000000000",
+            "safeguarded_snapshot_count": "0", "ignore_user_flash_copy_maps": "no",
+            "partition_id": "0", "partition_name": "ptn_test", "restore_in_progress": "no",
+            "owner_type": "none", "draft_partition_id": "", "draft_partition_name": "",
+            "last_restore_time": "", "dr_replicated": "no", "partition_default": "no",
+            "host_provisioned_capacity": "4.00GB", "anomaly_sequence_number": "",
+            "uuid": "9C16DE02-1F11-528A-B978-805E906C5B3B"}
+
+        volume_list = [
+            {"id": "61", "name": "clone_vol_01", "IO_group_id": "0",
+             "IO_group_name": "io_grp0", "status": "online", "mdisk_grp_id": "0",
+             "mdisk_grp_name": "pool1", "capacity": "1.00GB", "type": "striped",
+             "volume_type": "clone", "source_volume_id": "15", "source_volume_name": "test_vol_1",
+             "source_snapshot": "snapshot_id_1234"},
+            {"id": "62", "name": "clone_vol_02", "IO_group_id": "0",
+             "IO_group_name": "io_grp0", "status": "online", "mdisk_grp_id": "0",
+             "mdisk_grp_name": "pool1", "capacity": "1.00GB", "type": "striped",
+             "volume_type": "clone", "source_volume_id": "15", "source_volume_name": "test_vol_2",
+             "source_snapshot": "snapshot_id_1234"},
+            {"id": "63", "name": "clone_vol_03", "IO_group_id": "0",
+             "IO_group_name": "io_grp0", "status": "online", "mdisk_grp_id": "0",
+             "mdisk_grp_name": "pool1", "capacity": "1.00GB", "type": "striped",
+             "volume_type": "clone", "source_volume_id": "15", "source_volume_name": "test_vol_3",
+             "source_snapshot": "snapshot_id_1234"},
+            {"id": "64", "name": "clone_vol_04", "IO_group_id": "0",
+             "IO_group_name": "io_grp0", "status": "online", "mdisk_grp_id": "0",
+             "mdisk_grp_name": "pool1", "capacity": "1.00GB", "type": "striped",
+             "volume_type": "clone", "source_volume_id": "15", "source_volume_name": "test_vol_4",
+             "source_snapshot": "snapshot_id_1234"}]
+
+        svc_obj_info_mock.return_value = volume_list
+
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'username': 'username',
+            'password': 'password',
+            'name': 'clone_name_01',
+            'state': 'present',
+            'snapshot': 'snapshot_id_1234',
+            'pool': 'new_pool1'
+        }):
+            with pytest.raises(AnsibleFailJson) as exc:
+                clone = IBMSVClone()
+                clone.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+            self.assertEqual(exc.value.args[0]['msg'],
+                             "Modifications of clone is not supported via this module, Please use ibm_svc_manage_volume or "
+                             "ibm_svc_manage_volumegroup for modifying volume or volumegroup clone/thinclone respectively.")

--- a/tests/unit/plugins/modules/test_ibm_svc_manage_volume.py
+++ b/tests/unit/plugins/modules/test_ibm_svc_manage_volume.py
@@ -1095,16 +1095,10 @@ class TestIBMSVCvolume(unittest.TestCase):
             self.assertTrue(exc.value.args[0]['changed'])
 
     @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
-           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
-    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
-           'ibm_svc_manage_volume.IBMSVCvolume.get_existing_volume')
-    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
-           'ibm_svc_manage_volume.IBMSVCvolume.assemble_iogrp')
-    @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
-           'ibm_svc_manage_volume.IBMSVCvolume.mandatory_parameter_validation')
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
     @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
            'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
-    def test_module_for_creating_deduplicated_volume(self, auth_mock, c1, c2, c3, c4):
+    def test_failure_create_volume_with_deduplicated(self, svc_authorize_mock, svc_obj_info_mock):
         with set_module_args({
             'clustername': 'clustername',
             'domain': 'domain',
@@ -1115,18 +1109,14 @@ class TestIBMSVCvolume(unittest.TestCase):
             'size': '1',
             'unit': 'gb',
             'pool': 'test_pool',
-            'iogrp': 'io_grp0, io_grp1',
             'deduplicated': True,
         }):
-            c3.return_value = []
-            c4.return_value = {
-                'id': '25',
-                'message': 'Volume, id [25], successfully created'
-            }
-            with pytest.raises(AnsibleExitJson) as exc:
+            svc_obj_info_mock.side_effect = [{}]
+            with pytest.raises(AnsibleFailJson) as exc:
                 v = IBMSVCvolume()
                 v.apply()
-            self.assertTrue(exc.value.args[0]['changed'])
+            self.assertTrue(exc.value.args[0]['failed'])
+            self.assertEqual(exc.value.args[0]['msg'], "Parameter [deduplicated] is invalid without [thin] or [compressed]")
 
     @patch('ansible_collections.ibm.storage_virtualize.plugins.modules.'
            'ibm_svc_manage_volume.IBMSVCvolume.get_existing_volume')
@@ -2668,6 +2658,259 @@ class TestIBMSVCvolume(unittest.TestCase):
                 v.apply()
             self.assertTrue(exc.value.args[0]['failed'])
             self.assertEqual(exc.value.args[0]['msg'], "value of grainsize must be one of: 32, 64, 128, 256, got: 55")
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_volume_with_cache(self, svc_authorize_mock, svc_run_command_mock, svc_obj_info_mock):
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'present',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'pool': 'test_pool',
+            'size': '1',
+            'unit': 'gb',
+            'thin': True,
+            'cache': 'none'
+        }):
+            svc_obj_info_mock.side_effect = [{}]
+            svc_run_command_mock.return_value = {
+                'id': '26',
+                'message': 'Volume, id [26], successfully created'
+            }
+            with pytest.raises(AnsibleExitJson) as exc:
+                v = IBMSVCvolume()
+                v.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_volume_with_cache(self, svc_authorize_mock, svc_run_command_mock, svc_obj_info_mock):
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'present',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'pool': 'test_pool',
+            'size': '1',
+            'unit': 'gb',
+            'thin': True,
+            'cache': 'readwrite'
+        }):
+            svc_obj_info_mock.side_effect = [
+                [
+                    {"mdisk_grp_name": "test_pool", "capacity": "1073741824", "RC_name": "", "type": "striped", "cache": "none"},
+                    {"se_copy": "yes", "compressed_copy": "no"}
+                ]
+            ]
+            with pytest.raises(AnsibleExitJson) as exc:
+                v = IBMSVCvolume()
+                v.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_volume_with_preferrednode(self, svc_authorize_mock, svc_run_command_mock, svc_obj_info_mock):
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'present',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'pool': 'test_pool',
+            'size': '1',
+            'unit': 'gb',
+            'preferrednode': 'node1',
+            'iogrp': 'io_grp0'
+        }):
+            svc_obj_info_mock.side_effect = [
+                # lsvdisk OP:
+                {},
+                # lsiogrp OP:
+                [
+                    {"id": "0", "name": "io_grp0", "node_count": "2"},
+                    {"id": "1", "name": "io_grp1", "node_count": "0"},
+                    {"id": "2", "name": "io_grp2", "node_count": "0"},
+                    {"id": "3", "name": "io_grp3", "node_count": "0"},
+                    {"id": "4", "name": "recovery_io_grp", "node_count": "0"}
+                ]
+            ]
+            svc_run_command_mock.return_value = {
+                'id': '27',
+                'message': 'Volume, id [27], successfully created'
+            }
+            with pytest.raises(AnsibleExitJson) as exc:
+                v = IBMSVCvolume()
+                v.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_failure_create_volume_with_preferrednode(self, svc_authorize_mock, svc_obj_info_mock):
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'present',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'pool': 'test_pool',
+            'size': '1',
+            'unit': 'gb',
+            'preferrednode': 'node1'
+        }):
+            svc_obj_info_mock.side_effect = [{}]
+            with pytest.raises(AnsibleFailJson) as exc:
+                v = IBMSVCvolume()
+                v.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+            self.assertEqual(exc.value.args[0]['msg'], "Parameter [preferrednode] is only valid with a single iogrp.")
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_failure_update_volume_with_preferrednode(self, svc_authorize_mock, svc_obj_info_mock):
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'present',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'pool': 'test_pool',
+            'size': '1',
+            'unit': 'gb',
+            'preferrednode': 'node2',
+            'iogrp': 'io_grp0'
+        }):
+            svc_obj_info_mock.side_effect = [
+                # lsvdisk OP:
+                [
+                    {"mdisk_grp_name": "test_pool", "capacity": "1073741824", "RC_name": "", "type": "striped", "preferred_node_name": "node1"},
+                    {"real_capacity": "1073741824", "compressed_copy": "yes"}
+                ],
+                # lsiogrp OP:
+                [
+                    {"id": "0", "name": "io_grp0", "node_count": "2"},
+                    {"id": "1", "name": "io_grp1", "node_count": "0"},
+                    {"id": "2", "name": "io_grp2", "node_count": "0"},
+                    {"id": "3", "name": "io_grp3", "node_count": "0"},
+                    {"id": "4", "name": "recovery_io_grp", "node_count": "0"}
+                ],
+                # lsrcrelationship OP:
+                [
+                    {"vdisk_id": "28", "vdisk_name": "test_volume", "IO_group_id": "0", "IO_group_name": "io_grp0"}
+                ]
+            ]
+            with pytest.raises(AnsibleFailJson) as exc:
+                v = IBMSVCvolume()
+                v.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+            self.assertEqual(exc.value.args[0]['msg'], "Update not supported for parameter(s): preferrednode")
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_create_volume_with_autoexpand(self, svc_authorize_mock, svc_run_command_mock, svc_obj_info_mock):
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'present',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'pool': 'test_pool',
+            'size': '1',
+            'unit': 'gb',
+            'autoexpand': 'off',
+            'thin': True
+        }):
+            svc_obj_info_mock.side_effect = [{}]
+            svc_run_command_mock.return_value = {
+                'id': '28',
+                'message': 'Volume, id [28], successfully created'
+            }
+            with pytest.raises(AnsibleExitJson) as exc:
+                v = IBMSVCvolume()
+                v.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_run_command')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_update_volume_with_autoexpand(self, svc_authorize_mock, svc_run_command_mock, svc_obj_info_mock):
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'present',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'pool': 'test_pool',
+            'size': '1',
+            'unit': 'gb',
+            'autoexpand': 'on',
+        }):
+            svc_obj_info_mock.side_effect = [
+                [
+                    {"mdisk_grp_name": "test_pool", "capacity": "1073741824", "RC_name": "", "type": "striped", "cache": "none"},
+                    {"real_capacity": "1073741820", "compressed_copy": "no", "autoexpand": "off"}
+                ]
+            ]
+            with pytest.raises(AnsibleExitJson) as exc:
+                v = IBMSVCvolume()
+                v.apply()
+            self.assertTrue(exc.value.args[0]['changed'])
+
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi.svc_obj_info')
+    @patch('ansible_collections.ibm.storage_virtualize.plugins.module_utils.'
+           'ibm_svc_utils.IBMSVCRestApi._svc_authorize')
+    def test_failure_create_volume_with_autoexpand(self, svc_authorize_mock, svc_obj_info_mock):
+        with set_module_args({
+            'clustername': 'clustername',
+            'domain': 'domain',
+            'state': 'present',
+            'username': 'username',
+            'password': 'password',
+            'name': 'test_volume',
+            'pool': 'test_pool',
+            'size': '1',
+            'unit': 'gb',
+            'autoexpand': 'off',
+        }):
+            svc_obj_info_mock.side_effect = [{}]
+            with pytest.raises(AnsibleFailJson) as exc:
+                v = IBMSVCvolume()
+                v.apply()
+            self.assertTrue(exc.value.args[0]['failed'])
+            self.assertEqual(exc.value.args[0]['msg'], "Parameter [autoexpand] is invalid without [thin]")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ibm.storage_virtualize

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

# Features:
Enabling support for logging in via partition ip
Modified partition_migration_host_action playbook to support iSCSI hosts
Added volume parameters autoexpand, preferrednode and cache

# Module changes:
ibm_sv_manage_clone - Added new module to manage clone and thinclone of volume and volumegroup.
ibm_svc_manage_volume - Added support for autoexpand, preferrednode and cache parameters
ibm_sv_manage_replication_policy - Enabled support for logging in via partition ip 