### PR TITLE
Adding changes for 3.3.0 release

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -238,7 +238,7 @@ releases:
       minor_changes:
         - ibm_svc_manage_volume - Added support for autoexpand, preferrednode and cache parameters
         - ibm_sv_manage_replication_policy - Enabled support for logging in via partition ip
-      release_summary: Added support for looging in using the partition IP address across volume,
+      release_summary: Added support for logging in using the partition IP address across volume,
         volumegroup, host, hostcluster, snapshot, replication, and GAM modules, modified
         partition_migration_host_actions playbook for iSCSI hosts and added support for volume
         parameters autoexpand, preferrednode and cache.
@@ -247,3 +247,14 @@ releases:
         name: ibm_sv_manage_clone
         namespace: ''
     release_date: '2026-01-14'
+  3.3.0:
+    changes:
+      bugfixes:
+        - ibm_svc_manage_ip - Fixed issue related to VLAN while updating
+      minor_changes:
+        - ibm_svc_initial_setup - Added support for managing anomaly settings
+        - ibm_svc_manage_volume - Added support for addressing volume via UID
+      release_summary: Added support for addressing volume via UID in volume, volumegroup, host,
+        clone, mirror volume, migration, cloud_backup, flashcopy, snapshot, and vol_map modules,
+        added playbook for Fibre Channel zoning for Cisco SAN switches.
+    release_date: '2026-04-03'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,15 +2,17 @@
 
 namespace: ibm
 name: storage_virtualize
-version: 3.2.0
+version: 3.3.0
 readme: README.md
 authors:
   - Sumit Kumar Gupta (github.com/sumitguptaibm)
-  - Lavanya C R (github.com/lavanyacr)
   - Sandip G Rajbanshi (github.com/Sandip-Rajbanshi)
   - Rahul Pawar (github.com/rahul-p)
   - Aditya Bhosale (github.com/adityabhosale)
+  - Dhirender Singh (github.com/dhirendersingh19)
 description: Ansible Collections for IBM Storage Virtualize
+dependencies:
+  ansible.windows: ">=3.0.0"
 license_file: LICENSE
 tags:
 # tags so people can search for collections https://galaxy.ansible.com/search

--- a/playbooks/cisco_fc_zoning/README.md
+++ b/playbooks/cisco_fc_zoning/README.md
@@ -1,0 +1,114 @@
+# Automation of Fibre Channel Zoning for Cisco Switches
+
+
+## Table of Contents
+
+- [Objective](#objective)
+- [Prerequisites](#prerequisites)
+- [Variables](#variables)
+- [Playbook Overview](#playbook-overview)
+- [Sample Playbook Usage](#sample-playbook-usage)
+- [Authors](#authors)
+
+## Objective
+
+Automate and synchronize Fibre Channel zoning on Cisco SAN switches using zone data defined under `lshostzone` on IBM FlashSystem clusters.
+
+## Prerequisites
+
+- Controller Requirements:
+    - Python version 3.10 or later.
+    - Install **Ansible** (*v2.16* or later)
+    - Install **IBM Storage Virtualize Ansible Collection**:  
+        ```bash
+        ansible-galaxy collection install ibm.storage_virtualize
+        ```  
+    - Install **Cisco NX-OS Ansible Collection**:  
+        ```bash
+        ansible-galaxy collection install cisco.nxos
+        ```  
+    - Install Python dependency: **ansible-pylibssh**:  
+        ```bash
+        pip install ansible-pylibssh
+        ```  
+- IBM FlashSystem (*v9.1.2* or later)
+
+- Switch Requirements:
+    - Cisco MDS switch running NX-OS
+    - NX-OS version 8.4(1) or later
+
+## Variables
+
+  - **inventory.ini** - Defines the FlashSystem clusters and Cisco switches managed by the playbook.
+  ```ini
+    ; Inventory File - inventory.ini
+    [clusters]
+    cluster1 ansible_host=x.x.x.x ansible_user=username ansible_password=password
+    cluster2 ansible_host=x.x.x.x ansible_user=username ansible_password=password
+
+    [switches]
+    switch1 ansible_host=x.x.x.x ansible_user=username ansible_password=password
+    switch2 ansible_host=x.x.x.x ansible_user=username ansible_password=password
+  ```
+
+## Playbook Overview
+
+The automation consists of two playbooks:
+
+### 1. main.yaml:
+  - Entry point for execution. 
+  - Run using:
+     ```bash
+     ansible-playbook main.yaml -i inventory.ini
+     ```  
+  - Target group: **clusters**
+  - Collects all required data from the clusters.
+  - Invokes **cisco_zone_sync.yaml** to apply zoning on the switches
+
+### 2. cisco_zone_sync.yaml:
+  - Target group: **switches**
+  - Generates zone configurations based on the collected cluster data.
+  - Pushes the generated zone configurations to the Cisco switches.
+
+## Sample Playbook Usage
+- On the FlashSystem cluster, create an FC portset with auto-zoning enabled:
+  ```yaml
+  - name: Create a portset
+    ibm.storage_virtualize.ibm_svctask_command:
+      command: "svctask mkportset -name {{ portset_name }} -porttype fc -autozoneenabled yes"
+      clustername: "{{ clustername }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+  ```
+- Associate FlashSystem Fibre Channel I/O port ID that will be used for host connectivity to this portset.
+  ```yaml
+  - name: Add port ID to the portset
+    ibm.storage_virtualize.ibm_svctask_command:
+      command: "svctask addfcportsetmember -portset {{ portset_name }} -fcioportid {{ fcioportid }} -ignoreautozoneincapable"
+      clustername: "{{ clustername }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+  ```
+> [!NOTE]
+> Ensure the `ignoreautozoneincapable` flag is used when adding ports.
+- Map this portset to the host object.
+  ```yaml
+  - name: Create a host and map to portset
+    ibm.storage_virtualize.ibm_svctask_command:
+      command: "svctask mkhost -fcwwpn {{ fcwwpn }} -portset {{ portset_name }}"
+      clustername: "{{ clustername }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+  ```
+- On the controller, navigate to the playbook directory and update `inventory.ini` with the FlashSystem and Cisco switch credentials.
+- Run the playbook:
+  ```bash
+  ansible-playbook main.yaml -i inventory.ini
+  ```
+- The playbook creates Fibre Channel zones based on the configuration reported by the `lshostzone` command on the FlashSystem.
+- If the configuration changes, rerun the playbook to synchronize the zones with the updated configuration.
+
+## Authors
+
+- Om Dhumal (om.d@ibm.com)
+- Pravin Mahajan (pravimah@in.ibm.com)

--- a/playbooks/cisco_fc_zoning/cisco_zone_sync.yaml
+++ b/playbooks/cisco_fc_zoning/cisco_zone_sync.yaml
@@ -1,0 +1,552 @@
+- name: Cisco SAN Zoning - zone sync
+  hosts: switches
+  gather_facts: false
+  connection: network_cli
+  vars:
+    ansible_connection: network_cli
+    ansible_network_os: cisco.nxos.nxos
+    ansible_become: true
+    ansible_become_method: enable
+
+  tasks:
+
+    - name: Add switch SSH key if missing
+      ansible.builtin.shell: |
+        ssh-keygen -F {{ hostvars[inventory_hostname].ansible_host }} >/dev/null ||
+        ssh-keyscan -H {{ hostvars[inventory_hostname].ansible_host }} >> ~/.ssh/known_hosts
+      delegate_to: localhost
+      changed_when: false
+
+    - name: Gather VSAN and Zoneset configuration from switch
+      cisco.nxos.nxos_command:
+        commands:
+          - show fcdomain | grep 'VSAN\| Running fabric name'
+          - show zoneset active | grep -w 'zoneset'
+      register: switch_vsan_zoneset_info
+
+      # ===============================
+      # Sample Output
+      # ===============================
+      #
+      # show fcdomain | grep 'VSAN\| Running fabric name'
+      #           "VSAN 2",
+      #           "        Running fabric name: 20:02:00:08:31:31:c0:c1",
+      #           "VSAN 20",
+      #           "        Running fabric name: 20:14:00:08:31:31:c0:c1"
+      #
+      # show zoneset active | grep -w 'zoneset'
+      #           "zoneset name FS_cluster_000003052451E19D vsan 2",
+      #           "zoneset name ZS_VSAN20 vsan 20"
+      #
+      # switch_vsan_zoneset_info.stdout_lines
+      # [
+      #       [
+      #           "VSAN 2",
+      #           "        Running fabric name: 20:02:00:08:31:31:c0:c1",
+      #           "VSAN 20",
+      #           "        Running fabric name: 20:14:00:08:31:31:c0:c1"
+      #       ],
+      #       [
+      #           "zoneset name FS_cluster_000003052451E19D vsan 2",
+      #           "zoneset name ZS_VSAN20 vsan 20"
+      #       ]
+      # ]
+
+
+    - name: Map Fabric Name to VSAN ID
+      ansible.builtin.set_fact:
+        fabric_vsan_mapping: >-
+          {# Init empty dicts #}
+          {%- set fabric_to_vsan = {} -%}
+          {%- set vsan_to_fabric = {} -%}
+
+          {# Loop through output of show fcdomain in pairs: [VSAN line, Fabric line] #}
+          {%- for i in range(0, switch_vsan_zoneset_info.stdout_lines[0] | length, 2) -%}
+
+            {%- set vsan = switch_vsan_zoneset_info.stdout_lines[0][i].split(' ')[1].strip() -%}
+            {%- set fabric = switch_vsan_zoneset_info.stdout_lines[0][i+1].split(':', 1)[1].strip().replace(':','').upper() -%}
+            {%- set _ = fabric_to_vsan.update({fabric: vsan}) -%}
+            {%- set _ = vsan_to_fabric.update({vsan: fabric}) -%}
+
+          {%- endfor -%}
+
+          {{ {
+            "fabric_to_vsan": fabric_to_vsan,
+            "vsan_to_fabric": vsan_to_fabric
+          } }}
+
+      # ===============================
+      # fabric_vsan_mapping (sample output)
+      # ===============================
+      #
+      # {
+      #   "fabric_to_vsan": {
+      #     "200200083131C0C1": "2",
+      #     "201400083131C0C1": "20"
+      #   },
+      #   "vsan_to_fabric": {
+      #     "2":  "200200083131C0C1",
+      #     "20": "201400083131C0C1"
+      #   }
+      # }
+
+
+    - name: Map Vsan - Active Zoneset
+      ansible.builtin.set_fact:
+        vsan_zoneset_map: >-
+          {# Build dict: {vsan_id: zoneset_name} from show zoneset active cli #}
+          {%- set result = {} -%}
+
+          {# Loop through output of show zoneset active #}
+          {%- for line in switch_vsan_zoneset_info.stdout_lines[1] -%}
+
+            {%- if 'zoneset name' in line and 'vsan' in line -%}
+
+              {%- set words = line.split() -%}
+              {%- set zoneset_index = words.index('name') + 1 -%}
+              {%- set vsan_index = words.index('vsan') + 1 -%}
+              {%- set zoneset_name = words[zoneset_index] -%}
+              {%- set vsan_id = words[vsan_index] -%}
+              {%- set _ = result.update({vsan_id: zoneset_name}) -%}
+
+            {%- endif -%}
+
+          {%- endfor -%}
+          {{ result }}
+
+      # ===============================
+      # vsan_zoneset_map (sample output)
+      # ===============================
+      #
+      # {
+      #   "2":  "FS_cluster_000003052451E19D",
+      #   "20": "ZS_VSAN20"
+      # }
+
+
+    - name: Map vsan - Target Port data
+      ansible.builtin.set_fact:
+        vsan_targetports_map: >-
+          {# Initialize empty dict for results #}
+          {%- set result = {} -%}
+
+          {# Loop through all VSANs #}
+          {%- for vsan in vsan_zoneset_map.keys() -%}
+
+            {# Get fabric WWN corresponding to this VSAN #}
+            {%- set fabric = fabric_vsan_mapping.vsan_to_fabric[vsan] -%}
+
+            {# Collect all fc_io_port_ids in this fabric #}
+            {%- set fc_ioportids = cluster_info.Portfc
+                                    | selectattr('fabric_WWN', 'equalto', fabric)
+                                    | map(attribute='fc_io_port_id')
+                                    | list -%}
+
+            {# Find target ports whose fc_io_port_id belongs to this fabric #}
+            {%- set ports = cluster_info.Targetportfc
+                            | selectattr('fc_io_port_id', 'in', fc_ioportids)
+                            | list -%}
+
+            {# Add mapping: vsan -> list of target port data #}
+            {%- set _ = result.update({vsan: ports}) -%}
+
+          {%- endfor -%}
+          {{ result }}
+
+      # ===============================
+      # vsan_targetports_map (sample output)
+      # ===============================
+      #
+      # "2": [
+      #   {
+      #     "WWNN":               "300307680C00BC5A",
+      #     "WWPN":               "300307680C36BC5A",
+      #     "active_login_count": "0",
+      #     "current_node_id":    "1",
+      #     "fc_io_port_id":      "6",
+      #     "host_count":         "2",
+      #     "host_io_permitted":  "yes",
+      #     "id":                 "17",
+      #     "nportid":            "4B032E",
+      #     "owning_node_id":     "1",
+      #     "port_id":            "6",
+      #     "portset_count":      "2",
+      #     "protocol":           "scsi",
+      #     "virtualized":        "yes"
+      #   },
+      #   {
+      #     "WWNN":               "300307680C00BC5A",
+      #     "WWPN":               "300307680C37BC5A",
+      #     "active_login_count": "1",
+      #     "current_node_id":    "1",
+      #     "fc_io_port_id":      "7",
+      #     "host_count":         "2",
+      #     "host_io_permitted":  "yes",
+      #     "id":                 "20",
+      #     "nportid":            "4B032B",
+      #     "owning_node_id":     "1",
+      #     "port_id":            "7",
+      #     "portset_count":      "2",
+      #     "protocol":           "scsi",
+      #     "virtualized":        "yes"
+      #   }
+      # ],
+      #
+      # "20": []
+
+    - name: Set zone prefix and zone id
+      ansible.builtin.set_fact:
+        zone_prefix: >-
+            {{  (cluster_info.System.auto_zone_prefix | trim) + '_IBM_SV'
+                if (cluster_info.System.auto_zone_prefix | trim) != ""
+                else 'IBM_SV'
+             }}
+        zone_id: '00'
+
+    - name: Fetch existing zones for the particular Principle Member
+      cisco.nxos.nxos_command:
+        commands: >-
+          {# Initialize an empty list of CLI commands #}
+          {%- set result = [] -%}
+
+          {# Iterate through each VSAN and its mapped target ports #}
+          {%- for vsan, targetports in vsan_targetports_map.items() -%}
+
+            {# For every port in this VSAN, build a zone-check command #}
+            {%- for port in targetports -%}
+
+              {# Command format: show zone name <zone_prefix>_<WWPN>_<zone_id> vsan <vsan> #}
+              {%- set zone_name = zone_prefix ~ "_" ~ port.WWPN ~ "_" ~ zone_id -%}
+              {%- set _ = result.append("show zone name " ~ zone_name ~ " vsan " ~ vsan) -%}
+
+            {%- endfor -%}
+
+          {%- endfor -%}
+          {{ result }}
+      register: existing_zones_raw
+
+      # ===============================
+      # existing_zones_raw.stdout_lines (sample output)
+      # ===============================
+      #
+      # [
+      #   [
+      #     "zone name IBM_SVC_300307680C00BC5A_300307680C36BC5A vsan 2",
+      #     "  pwwn 30:03:07:68:0c:36:bc:5a",
+      #     "  pwwn 40:00:00:10:9b:0f:db:f4"
+      #   ],
+      #   [
+      #     "zone name IBM_SVC_300307680C00BC5A_300307680C37BC5A vsan 2",
+      #     "  pwwn 30:03:07:68:0c:37:bc:5a",
+      #     "  pwwn 40:00:00:10:9b:0f:db:f5"
+      #   ],
+      #   [
+      #     "zone name IBM_SVC_300307690C005D2E_300307690C365D2E vsan 20",
+      #     "  pwwn 30:03:07:69:0c:36:5d:2e",
+      #     "  pwwn 40:00:00:10:9b:0f:db:f4"
+      #   ]
+      # ]
+
+
+    - name: Parse existing zones from active zoneset
+      ansible.builtin.set_fact:
+        vsan_existing_zone_map: >-
+          {# Initialize result dict: {vsan_id: {zone_name: [pwwns]}} #}
+          {%- set result = {} -%}
+
+          {# Loop through command outputs from previous task #}
+          {%- for lines in existing_zones_raw.stdout_lines -%}
+
+            {# Skip if CLI returned "Zone not present" #}
+            {%- if "Zone not present" not in lines[0] -%}
+
+              {# Extract zone name and VSAN ID from the first line #}
+              {%- set words = lines[0].split() -%}
+              {%- set zone_name = words[2] -%}
+              {%- set vsan_id = words[4] -%}
+
+              {# Collect all PWWN members from the remaining lines #}
+              {%- set zone_members = [] -%}
+              {%- for line in lines[1:] -%}
+                {%- if 'pwwn' in line -%}
+                  {%- set pwwn = line.split()[1] -%}
+                  {%- set _ = zone_members.append(pwwn) -%}
+                {%- endif -%}
+              {%- endfor -%}
+
+              {# Build entry: {zone_name: [unique pwwns]} #}
+              {%- set zone_entry = {zone_name: zone_members | unique} -%}
+
+              {# Merge into result for this VSAN:
+                  - If vsan_id exists -> update it
+                  - Else -> create new entry
+              #}
+              {%- if vsan_id in result -%}
+                {%- set _ = result[vsan_id].update(zone_entry) -%}
+              {%- else -%}
+                {%- set _ = result.update({vsan_id: zone_entry}) -%}
+              {%- endif -%}
+
+            {%- endif -%}
+
+          {%- endfor -%}
+          {{ result }}
+
+      # ===============================
+      # vsan_existing_zone_map (sample output)
+      # ===============================
+      #
+      # {
+      #   "2": {
+      #     "IBM_SVC_300307680C005D2E_300307680C365D2E": [
+      #       "30:03:07:68:0c:36:5d:2e",
+      #       "40:00:00:10:9b:0f:db:f4"
+      #     ],
+      #     "IBM_SVC_300307680C005D2E_300307680C375D2E": [
+      #       "30:03:07:68:0c:37:5d:2e",
+      #       "40:00:00:10:9b:0f:db:f5"
+      #     ]
+      #   },
+      #
+      #   "20": {
+      #     "IBM_SVC_300307690C00AC4A_300307690C36AC4A": [
+      #       "30:03:07:69:0c:36:ac:4a",
+      #       "40:00:00:10:9b:0f:db:f4"
+      #     ]
+      #   }
+      # }
+
+
+    - name: Create New Zone definition from Cluster - Host Zone data
+      ansible.builtin.set_fact:
+        vsan_new_zone_map: >-
+          {# Namespace holds:
+            - result: final dict {vsan_id: {zone_name: [members]}}
+            - new_zones: temporary dict per fabric
+          #}
+          {%- set glob_vars = namespace(result={}, new_zones={}) -%}
+
+          {# Iterate over each fabric #}
+          {%- for fabric in fabric_vsan_mapping.fabric_to_vsan.keys() -%}
+
+            {# Get VSAN ID for this fabric #}
+            {%- set vsan = fabric_vsan_mapping.fabric_to_vsan[fabric] -%}
+
+            {# Reset zones for this fabric before building new ones #}
+            {%- set glob_vars.new_zones = {} -%}
+
+            {# Select host zone entry in this fabric that require zoning #}
+            {%- set host_zone = cluster_info.Hostzone
+              | selectattr('ioport_fabric', 'equalto', fabric)
+              | selectattr('recommended_config', 'equalto', 'zone_needed')
+              | list
+            -%}
+
+            {# Iterate through each host zone entry needing zoning #}
+            {%- for item1 in host_zone -%}
+
+              {#
+                Find the corresponding target port wwpn from fcioportid present
+                in host zone entry. Check host zone output for better clarity.
+              #}
+              {%- set target_ports = cluster_info.Targetportfc
+                | selectattr('fc_io_port_id', 'equalto', item1.io_port_id)
+                | selectattr('protocol', 'equalto', 'scsi')
+                | selectattr('virtualized', 'equalto', 'yes')
+                | list
+              -%}
+
+              {# Iterate through each target port #}
+              {%- for item2 in target_ports -%}
+
+                {%- set item_key = item2.WWPN -%}
+
+                {# Zone naming convention: <zone_prefix>_<WWPN> #}
+                {%- set zone_name = zone_prefix ~ "_" ~ item2.WWPN ~ "_" ~ zone_id -%}
+
+                {# Zone members:
+                  - target WWPN (formatted with colons, lowercased)
+                  - host WWPN (formatted with colons, lowercased)
+                  - If zone already exists, append instead of overwrite
+                #}
+                {%- set glob_vars.new_zones = glob_vars.new_zones
+                  | combine({
+                      zone_name: (
+                        (glob_vars.new_zones[zone_name]
+                          if glob_vars.new_zones[zone_name] is defined
+                          else [item2.WWPN | regex_replace('(..)(?=.)', '\\1:') | lower])
+                        + [item1.host_wwpn | regex_replace('(..)(?=.)', '\\1:') | lower]
+                      )
+                    })
+                -%}
+
+              {%- endfor -%}
+
+            {%- endfor -%}
+
+            {# Add this fabrics zones to the final result under its VSAN #}
+            {%- set _ = glob_vars.result.update({vsan: glob_vars.new_zones}) -%}
+          {%- endfor -%}
+
+          {{ glob_vars.result }}
+
+      # ===============================
+      # vsan_new_zone_map (sample output)
+      # ===============================
+      #
+      # {
+      #   "2": {
+      #     "IBM_SVC_300307680C005D2E_300307680C365D2E": [
+      #       "30:03:07:68:0c:36:5d:2e",
+      #       "40:00:00:10:9b:0f:db:f4",
+      #       "40:00:00:10:9b:0f:db:f5"
+      #     ]
+      #   },
+      #
+      #   "20": {
+      #     "IBM_SVC_300307690C00AC4A_300307690C36AC4A": [
+      #       "30:03:07:69:0c:36:ac:4a",
+      #       "40:00:00:10:9b:0f:db:f4",
+      #       "40:00:00:10:9b:0f:db:f5"
+      #     ]
+      #   }
+      # }
+
+
+    - name: Build zoning update definition per VSAN
+      ansible.builtin.set_fact:
+        zone_zoneset_details: >-
+          {# Final structure: list of zone/zoneset updates for each VSAN #}
+          {%- set zone_zoneset_details = [] -%}
+
+          {# Iterate over each fabric #}
+          {%- for fabric in fabric_vsan_mapping.fabric_to_vsan.keys() -%}
+
+            {# Set vsan, active_zoneset #}
+            {%- set vsan = fabric_vsan_mapping.fabric_to_vsan[fabric] -%}
+            {%- set active_zoneset =  vsan_zoneset_map[vsan] -%}
+
+            {# Temp lists to collect zone and zoneset changes for this VSAN #}
+            {%- set zones = [] -%}
+            {%- set zoneset_members = [] -%}
+
+            {# Existing zones in this VSAN (from switch) #}
+            {% set old_zones = {} %}
+            {% if vsan_existing_zone_map[vsan] is defined %}
+                {% set old_zones = vsan_existing_zone_map[vsan] %}
+            {% endif %}
+
+            {# New zones in this VSAN (from cluster - lshostzone) #}
+            {% set new_zones = {} %}
+            {% if vsan_new_zone_map[vsan] is defined %}
+                {% set new_zones = vsan_new_zone_map[vsan] %}
+            {% endif %}
+
+            {# --- Compare new zones against existing zones --- #}
+            {% for key, value in new_zones.items() %}
+
+              {%- set existing_members   = (old_zones[key] if old_zones[key] is defined else []) -%}
+              {%- set new_def_members    = value -%}
+              {%- set cisco_zone_members = [] -%}
+
+              {# Find members to remove: in existing but not in new definition #}
+              {%- set mem_to_remove =  existing_members | reject('in', new_def_members) | list -%}
+
+              {# Find members to add: in new definition but not in existing #}
+              {%- set mem_to_add    =  new_def_members | reject('in', existing_members) | list -%}
+
+              {# Build member entries for removal #}
+              {%- for wwpn in mem_to_remove -%}
+                {%- set _ = cisco_zone_members.append({'remove': True, 'pwwn': wwpn }) -%}
+              {%- endfor -%}
+
+              {# Build member entries for addition #}
+              {%- for wwpn in mem_to_add -%}
+                {%- set _ = cisco_zone_members.append({'remove': False, 'pwwn': wwpn }) -%}
+              {%- endfor -%}
+
+              {# Only create zone entry if there are changes #}
+              {%- if cisco_zone_members | length > 0 -%}
+                {%- set zone_entry = {'name': key, 'members': cisco_zone_members, 'remove': False} -%}
+                {%- set _ = zones.append(zone_entry) -%}
+                {%- set _ = zoneset_members.append({'name': key, 'remove': False}) -%}
+              {%- endif -%}
+
+            {% endfor %}
+
+            {# --- Identify zones that exist on switch but not in new definition -> remove them --- #}
+            {% set zones_to_be_removed = old_zones.keys() | reject('in', new_zones.keys()) | list  %}
+
+            {% for zone in zones_to_be_removed %}
+
+              {%- set zone_entry = {'name': zone, 'members': [], 'remove': True} -%}
+              {%- set _ = zones.append(zone_entry) -%}
+              {%- set _ = zoneset_members.append({'name': zone, 'remove': True}) -%}
+
+            {% endfor %}
+
+            {# Define the zoneset structure #}
+            {%- set zoneset = {'action': 'activate', 'name': active_zoneset, 'members': zoneset_members} -%}
+
+            {# Only include the zone/zoneset entry if there are any changes #}
+            {%- if zones | length > 0 -%}
+              {%- set cur_zone_zoneset_det = {'mode': 'basic', 'vsan': vsan, 'zone': zones, 'zoneset': [zoneset]} -%}
+              {%- set _ = zone_zoneset_details.append(cur_zone_zoneset_det) -%}
+            {%- endif -%}
+
+          {%- endfor -%}
+
+          {{ zone_zoneset_details | to_json }}
+
+      # ===============================
+      # zone_zoneset_details (sample output)
+      # ===============================
+      #
+      # [
+      #   {
+      #     "mode": "basic",
+      #     "vsan": "2",
+      #     "zone": [
+      #       {
+      #         "members": [
+      #           [
+      #             {
+      #               "pwwn": "40:00:00:10:9b:0f:db:f5",
+      #               "remove": false
+      #             }
+      #           ]
+      #         ],
+      #         "name": "IBM_SVC_300307680C005D2E_300307680C365D2E",
+      #         "remove": false
+      #       },
+      #       {
+      #         "members": [],
+      #         "name": "IBM_SVC_300307680C005D2E_300307680C375D2E",
+      #         "remove": true
+      #       }
+      #     ],
+      #     "zoneset": [
+      #       {
+      #         "action": "activate",
+      #         "members": [
+      #           {
+      #             "name": "IBM_SVC_300307680C005D2E_300307680C365D2E",
+      #             "remove": false
+      #           },
+      #           {
+      #             "name": "IBM_SVC_300307680C005D2E_300307680C375D2E",
+      #             "remove": true
+      #           }
+      #         ],
+      #         "name": "FS_cluster_000003052451E19D"
+      #       }
+      #     ]
+      #   }
+      # ]
+
+
+    - name: Send Zone Creation request
+      cisco.nxos.nxos_zone_zoneset:
+        # Pass in the computed zone/zoneset changes built in the previous task
+        zone_zoneset_details: "{{ zone_zoneset_details | from_json }}"
+      when: (zone_zoneset_details | from_json) != []

--- a/playbooks/cisco_fc_zoning/inventory.ini
+++ b/playbooks/cisco_fc_zoning/inventory.ini
@@ -1,0 +1,7 @@
+[clusters]
+cluster1 ansible_host=x.x.x.x ansible_user=superuser ansible_password=password
+; cluster2 ansible_host=x.x.x.x ansible_user=superuser ansible_password=password
+
+[switches]
+switch1 ansible_host=x.x.x.x ansible_user=admin ansible_password=password
+; switch2 ansible_host=x.x.x.x ansible_user=admin ansible_password=password

--- a/playbooks/cisco_fc_zoning/main.yaml
+++ b/playbooks/cisco_fc_zoning/main.yaml
@@ -1,0 +1,162 @@
+###################################################
+# Play 1: Pre-flight - Validate Switch Connectivity
+###################################################
+- name: Pre-flight - Validate switch connectivity and credentials
+  hosts: switches
+  gather_facts: false
+  connection: network_cli
+  any_errors_fatal: true
+  serial: 1
+  vars:
+    ansible_network_os: cisco.nxos.nxos
+    ansible_become: true
+    ansible_become_method: enable
+  tasks:
+
+    - name: Add switch SSH key if missing
+      ansible.builtin.shell: |
+        ssh-keygen -F {{ ansible_host }} >/dev/null ||
+        ssh-keyscan -H {{ ansible_host }} >> ~/.ssh/known_hosts
+      delegate_to: localhost
+      changed_when: false
+
+    - name: Validate switch connectivity and gather facts
+      block:
+        - name: Collect NX-OS facts
+          cisco.nxos.nxos_facts:
+            gather_subset:
+              - min
+
+        - name: Report switch validation result
+          ansible.builtin.debug:
+            msg: >-
+              [{{ inventory_hostname }}] ({{ ansible_host }}) -
+              Switch reachable and credentials valid.
+              Hostname: {{ ansible_net_hostname }}
+              NX-OS Version: {{ ansible_net_version }}
+
+      rescue:
+        - name: Report validation failure
+          ansible.builtin.fail:
+            msg: |
+              ============================================================
+              PRE-FLIGHT VALIDATION FAILED: {{ inventory_hostname }}
+              ============================================================
+              Host : {{ ansible_host }}
+              User : {{ ansible_user }}
+
+              Possible causes:
+                - Incorrect username or password in inventory
+                - Switch is unreachable at {{ ansible_host }}
+
+              Fix: Check credentials in your inventory file for [switches]
+              ============================================================
+
+###################################################
+# Main: Cisco SAN Zoning - Cluster Data Collection and Zone Sync
+###################################################
+- name: Cisco SAN Zoning - Cluster Data Collection
+  hosts: clusters
+  gather_facts: false
+  connection: local
+  tasks:
+
+      ###################################################
+      # Gather Data from FlashSystem Cluster
+      ##################################################
+
+    - name: Fetch authorization token for cluster
+      register: cluster_auth_info
+      no_log: true
+      ibm.storage_virtualize.ibm_svc_auth:
+        clustername: "{{ ansible_host }}"
+        username: "{{ ansible_user }}"
+        password: "{{ ansible_password }}"
+
+    - name: Fetch Host Zone, FC Port and Target Port data
+      register: cluster_info
+      ibm.storage_virtualize.ibm_svc_info:
+        clustername: "{{ ansible_host }}"
+        token: "{{ cluster_auth_info.token }}"
+        command_list: [lshostzone, lsportfc, lstargetportfc, lssystem]
+        objectname: all
+
+# ===============================
+# Sample CLI Output for Reference
+# ===============================
+#
+# lshostzone CLI output:-
+# +----+---------+------------+------------------+------------------+------------+--------------+------------+------------------+--------------------+---
+# | id | host_id | host_name  | host_wwpn        | host_fabric      | portset_id | portset_name | io_port_id | ioport_fabric    | recommended_config |
+# +----+---------+------------+------------------+------------------+------------+--------------+------------+------------------+--------------------+---
+# | 0  |    0    |   host0    | 30000020FF0A1B01 | 20020010AABBCC01 |     4      |     ps-1     |     6      | 20020010AABBCC01 |  zone_not_needed   |
+# | 1  |    0    |   host0    | 30000020FF0A1B01 | 20020010AABBCC01 |     4      |     ps-1     |     7      | 20020010AABBCC01 |  zone_needed       |
+# | 2  |    1    |   host1    | 30000020FF0A1B02 | 20020010AABBCC01 |     4      |     ps-1     |     6      | 20020010AABBCC01 |  zone_needed       |
+# | 3  |    1    |   host1    | 30000020FF0A1B02 | 20020010AABBCC01 |     4      |     ps-1     |     7      | 20020010AABBCC01 |  zone_not_needed   |
+# +----+---------+------------+------------------+------------------+------------+--------------+------------+------------------+--------------------+---
+# ---+-----------------+-------------+---------------------------+
+#    | applied_config  | zone_status | disruptive_change_pending |
+# ---+-----------------+-------------+---------------------------+
+#    | zone_needed     |  not_zoned  |            yes            |
+#    | zone_needed     |  not_zoned  |            no             |
+#    | zone_needed     |  not_zoned  |            no             |
+#    | zone_not_needed |  not_zoned  |            no             |
+# ---+-----------------+-------------+---------------------------+
+
+
+# lsportfc CLI output:-
+# +----+---------------+---------+------+------------+---------+-----------+------------------+---------+--------+------------------+------+--------+---
+# | id | fc_io_port_id | port_id | type | port_speed | node_id | node_name | WWPN             | nportid | status | switch_WWPN      | fpma | vlanid |
+# +----+---------------+---------+------+------------+---------+-----------+------------------+---------+--------+------------------+------+--------+---
+# | 5  |       6       |    6    |  fc  |    32Gb    |    1    |   node1   | 600507700C32AB10 | 4B022D  | active | 20020010AABBCC01 | N/A  |  N/A   |
+# | 6  |       7       |    7    |  fc  |    32Gb    |    1    |   node1   | 600507700C33AB13 | 4B022A  | active | 20020010AABBCC01 | N/A  |  N/A   |
+# +----+---------------+---------+------+------------+---------+-----------+------------------+---------+--------+------------------+------+--------+---
+# ---+---------+------------+---------------+------------------+-----------------+------------------+-----------------------------+----------------+
+#    | fcf_MAC | attachment | cluster_use   | adapter_location | adapter_port_id | fabric_WWN       | fabric_auto_zone_capability | port_max_speed |
+# ---+---------+------------+---------------+------------------+-----------------+------------------+-----------------------------+----------------+
+#    |   N/A   |   switch   | local_partner |        3         |        2        | 200100083131C0B1 |     incompatible_fabric     |      32Gb      |
+#    |   N/A   |   switch   | local_partner |        3         |        3        | 200100083131C0B1 |     incompatible_fabric     |      32Gb      |
+# ---+---------+------------+---------------+------------------+-----------------+------------------+-----------------------------+----------------+
+
+
+# lstargetportfc CLI output:-
+# +----+------------------+------------------+---------+----------------+-----------------+---------+-------------------+-------------+----------+---
+# | id | WWPN             | WWNN             | port_id | owning_node_id | current_node_id | nportid | host_io_permitted | virtualized | protocol |
+# +----+------------------+------------------+---------+----------------+-----------------+---------+-------------------+-------------+----------+---
+# | 16 | 600507700C32AB10 | 600507700C00AB10 |    6    |       1        |        1        | 4B022D  |        no         |     no      |   scsi   |
+# | 17 | 600507700C36AB11 | 600507700C00AB10 |    6    |       1        |        1        | 4B022E  |        yes        |     yes     |   scsi   |
+# | 18 | 600507700C3AAB12 | 600507700C00AB10 |    6    |       1        |        1        | 4B022F  |        yes        |     yes     |   nvme   |
+# | 19 | 600507700C33AB13 | 600507700C00AB10 |    7    |       1        |        1        | 4B022A  |        no         |     no      |   scsi   |
+# | 20 | 600507700C37AB14 | 600507700C00AB10 |    7    |       1        |        1        | 4B022B  |        yes        |     yes     |   scsi   |
+# | 21 | 600507700C3BAB15 | 600507700C00AB10 |    7    |       1        |        1        | 4B022C  |        yes        |     yes     |   nvme   |
+# | 22 | 600507700C34AB16 | 600507700C00AB10 |    8    |       1        |        1        | 010D00  |        no         |     no      |   scsi   |
+# | 23 | 600507700C38AB17 | 600507700C00AB10 |    8    |       1        |        1        | 010D01  |        yes        |     yes     |   scsi   |
+# | 24 | 600507700C3CAB18 | 600507700C00AB10 |    8    |       1        |        1        | 010D02  |        yes        |     yes     |   nvme   |
+# +----+------------------+------------------+---------+----------------+-----------------+---------+-------------------+-------------+----------+---
+# ---+--------------------+---------------+------------+--------------+
+#    | fc_ioport_id_count | portset_count | host_count | active_login |
+# ---+--------------------+---------------+------------+--------------+
+#    |         6          |       0       |     0      |      0       |
+#    |         6          |       2       |     2      |      1       |
+#    |         6          |       2       |     0      |      0       |
+#    |         7          |       0       |     0      |      0       |
+#    |         7          |       2       |     2      |      2       |
+#    |         7          |       2       |     0      |      0       |
+#    |         8          |       0       |     0      |      0       |
+#    |         8          |       1       |     0      |      0       |
+#    |         8          |       1       |     0      |      0       |
+# ---+--------------------+---------------+------------+--------------+
+
+    - name: Initiate zone synchronization for {{ inventory_hostname }}
+      ansible.builtin.command: >
+        ansible-playbook cisco_zone_sync.yaml
+        -i {{ ansible_inventory_sources[0] }}
+        --extra-vars '{"cluster_info": {{ cluster_info | to_json }} }'
+        -e "cluster_user={{ inventory_hostname }}"
+        -vvv
+      changed_when: false
+
+    - name: Report zone synchronization complete
+      ansible.builtin.debug:
+        msg: >-
+          [{{ inventory_hostname }}] Zone synchronization completed successfully.

--- a/playbooks/policy_based_replication/create_mTLS.yml
+++ b/playbooks/policy_based_replication/create_mTLS.yml
@@ -1,20 +1,16 @@
 ---
-- name: Fetch auth token
-  register: auth
-  no_log: true
-  ibm.storage_virtualize.ibm_svc_auth:
-    clustername: "{{ item.cluster_ip }}"
-    username: "{{ item.cluster_username }}"
-    password: "{{ item.cluster_password }}"
-    log_path: "{{ log_path | default('/tmp/ansiblePB.debug') }}"
-
 - name: Export SSL certificate internally
   ibm.storage_virtualize.ibm_sv_manage_ssl_certificate:
     clustername: "{{ item.cluster_ip }}"
-    token: "{{ auth.token }}"
+    token: "{{ item.token }}"
     log_path: "{{ log_path | default('/tmp/ansiblePB.debug') }}"
     certificate_type: "system"
-  loop: "{{ clusters_data }}"
+  loop:
+    - token: "{{ primary_auth.token }}"
+      cluster_ip: "{{ clusters_data[0].cluster_ip }}"
+    - token: "{{ secondary_auth.token }}"
+      cluster_ip: "{{ clusters_data[1].cluster_ip }}"
+  no_log: true
 
 - name: Create truststore on primary
   ibm.storage_virtualize.ibm_sv_manage_truststore_for_replication:
@@ -43,10 +39,10 @@
 - name: Enable PBR on partnership on both sides
   ibm.storage_virtualize.ibm_sv_manage_fc_partnership:
     clustername: "{{ clusters_data[0].cluster_ip }}"
-    token: "{{ auth.token }}"
+    token: "{{ primary_auth.token }}"
     log_path: "{{ log_path | default('/tmp/ansiblePB.debug') }}"
     remote_clustername: "{{ clusters_data[1].cluster_ip }}"
-    remote_token: "{{ clusters_data[1].token }}"
+    remote_token: "{{ secondary_auth.token }}"
     remote_system: "{{ clusters_data[1].cluster_name }}"
     state: present
     pbrinuse: "yes"

--- a/playbooks/policy_based_replication/drp_pool_setup.yml
+++ b/playbooks/policy_based_replication/drp_pool_setup.yml
@@ -1,8 +1,7 @@
 - name: Create mdiskgrp
   ibm.storage_virtualize.ibm_svc_mdiskgrp:
     clustername: "{{ item.cluster_ip }}"
-    username: "{{ item.cluster_username }}"
-    password: "{{ item.cluster_password }}"
+    token: "{{ item.token }}"
     log_path: "{{ log_path | default('/tmp/ansiblePB.debug') }}"
     name: "{{ item.pool_name | default('mdg0') }}"
     state: present
@@ -13,8 +12,7 @@
   register: pool_results
   ibm.storage_virtualize.ibm_svc_info:
     clustername: "{{ item.cluster_ip }}"
-    username: "{{ item.cluster_username }}"
-    password: "{{ item.cluster_password }}"
+    token: "{{ item.token }}"
     log_path: "{{ log_path | default('/tmp/ansiblePB.debug') }}"
     gather_subset: 'pool'
     objectname: "{{ item.pool_name | default('mdg0') }}"
@@ -31,15 +29,13 @@
       ibm.storage_virtualize.ibm_svc_info:
         gather_subset: "drive"
         clustername: "{{ item.cluster_ip }}"
-        username: "{{ item.cluster_username }}"
-        password: "{{ item.cluster_password }}"
+        token: "{{ item.token }}"
         log_path: "{{ log_path | default('/tmp/ansiblePB.debug') }}"
 
     - name: Make drive in candidate state
       ibm.storage_virtualize.ibm_sv_manage_drive:
         clustername: "{{ item.cluster_ip }}"
-        username: "{{ item.cluster_username }}"
-        password: "{{ item.cluster_password }}"
+        token: "{{ item.token }}"
         log_path: "{{ log_path | default('/tmp/ansiblePB.debug') }}"
         drive_id: "{{ drive.id }}"
         drive_state: candidate
@@ -54,8 +50,7 @@
         gather_subset: "drive"
         filtervalue: "use=candidate"
         clustername: "{{ item.cluster_ip }}"
-        username: "{{ item.cluster_username }}"
-        password: "{{ item.cluster_password }}"
+        token: "{{ item.token }}"
         log_path: "{{ log_path | default('/tmp/ansiblePB.debug') }}"
 
     - name: Get Total Drive count
@@ -75,8 +70,7 @@
     - name: Create distribute array
       ibm.storage_virtualize.ibm_svc_mdisk:
         clustername: "{{ item.cluster_ip }}"
-        username: "{{ item.cluster_username }}"
-        password: "{{ item.cluster_password }}"
+        token: "{{ item.token }}"
         log_path: "{{ log_path | default('/tmp/ansiblePB.debug') }}"
         name: mdisk0
         state: present
@@ -90,8 +84,7 @@
 - name: Create provisioning policy
   ibm.storage_virtualize.ibm_sv_manage_provisioning_policy:
     clustername: "{{ item.cluster_ip }}"
-    username: "{{ item.cluster_username }}"
-    password: "{{ item.cluster_password }}"
+    token: "{{ item.token }}"
     log_path: "{{ log_path | default('/tmp/ansiblePB.debug') }}"
     name: provisioning_policy0
     capacitysaving: "drivebased"

--- a/playbooks/policy_based_replication/main.yml
+++ b/playbooks/policy_based_replication/main.yml
@@ -33,7 +33,14 @@
 
     - name: Create mdiskgrp_drp and provisionpolicy on both the clusters
       ansible.builtin.include_tasks: drp_pool_setup.yml
-      loop: "{{ clusters_data }}"
+      loop:
+        - token: "{{ primary_auth.token }}"
+          cluster_ip: "{{ clusters_data[0].cluster_ip }}"
+          pool_name: "{{ clusters_data[0].pool_name | default('mdg0') }}"
+
+        - token: "{{ secondary_auth.token }}"
+          cluster_ip: "{{ clusters_data[1].cluster_ip }}"
+          pool_name: "{{ clusters_data[1].pool_name | default('mdg0') }}"
       no_log: true
 
     - name: Get mdisk info

--- a/plugins/module_utils/ibm_svc_ssh.py
+++ b/plugins/module_utils/ibm_svc_ssh.py
@@ -15,7 +15,7 @@ import uuid
 from ansible.module_utils.compat.paramiko import paramiko
 from ansible_collections.ibm.storage_virtualize.plugins.module_utils.ibm_svc_utils import get_logger
 
-COLLECTION_VERSION = "3.2.0"
+COLLECTION_VERSION = "3.3.0"
 
 
 class IBMSVCssh(object):

--- a/plugins/module_utils/ibm_svc_utils.py
+++ b/plugins/module_utils/ibm_svc_utils.py
@@ -20,7 +20,7 @@ from ansible.module_utils.urls import open_url
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 
-COLLECTION_VERSION = "3.2.0"
+COLLECTION_VERSION = "3.3.0"
 TIMEOUT = 600
 
 

--- a/plugins/modules/ibm_sv_manage_clone.py
+++ b/plugins/modules/ibm_sv_manage_clone.py
@@ -78,7 +78,7 @@ options:
         type: str
     fromsourcevolumes:
         description:
-            - Specifies colon-separated list of the parent volumes.
+            - Specifies colon-separated list of the parent volumes name/UID.
             - The parameters I(fromsourcevolumes) is mandatory for clone volumes and optional for clone volume groups
               while creating clone.
         type: str
@@ -123,7 +123,7 @@ notes:
 
 EXAMPLES = r'''
 - name: Create a clone of a volume from snapshot
-  ibm.storage_virtualize.ibm_svc_manage_clone:
+  ibm.storage_virtualize.ibm_sv_manage_clone:
     clustername: "{{ clustername }}"
     domain: "{{ domain }}"
     username: "{{ username }}"
@@ -139,7 +139,7 @@ EXAMPLES = r'''
     preferrednode: "node1"
     volumegroup: "Vg1"
 - name: Create a clone of a volumegroup from snapshot
-  ibm.storage_virtualize.ibm_svc_manage_clone:
+  ibm.storage_virtualize.ibm_sv_manage_clone:
     clustername: "{{ clustername }}"
     domain: "{{ domain }}"
     username: "{{ username }}"
@@ -154,7 +154,7 @@ EXAMPLES = r'''
     partition: "ptn1"
     ownershipgroup: "grp1"
 - name: Create a clone of volume vector from snapshot
-  ibm.storage_virtualize.ibm_svc_manage_clone:
+  ibm.storage_virtualize.ibm_sv_manage_clone:
     clustername: "{{ clustername }}"
     domain: "{{ domain }}"
     username: "{{ username }}"
@@ -404,7 +404,6 @@ class IBMSVClone(object):
                 )
         else:
             if 'pool' in props:
-                self.log("SGR pool in props")
                 # volumegroup's pool cannot be changed after creation
                 if self.check_volumes_in_pool(self.name, self.pool):
                     del props['pool']

--- a/plugins/modules/ibm_sv_manage_ip_partnership.py
+++ b/plugins/modules/ibm_sv_manage_ip_partnership.py
@@ -94,6 +94,7 @@ options:
     compressed:
         description:
             - Specifies whether compression is enabled for this partnership.
+            - C(compressed=yes) is not supported on FS5060, FS5600, FS7600, FS9600 platforms.
             - Valid when I(state=present).
         choices: [ 'yes', 'no' ]
         type: str

--- a/plugins/modules/ibm_sv_manage_snapshot.py
+++ b/plugins/modules/ibm_sv_manage_snapshot.py
@@ -73,7 +73,7 @@ options:
         type: str
     src_volume_names:
         description:
-            - Specifies the name of the volumes for which the snapshots are to be created.
+            - Specifies the name/UID of the volumes for which the snapshots are to be created.
             - List of volume names can be specified with the delimiter colon.
             - Valid when I(state=present), to create a snapshot.
         type: str

--- a/plugins/modules/ibm_sv_restore_cloud_backup.py
+++ b/plugins/modules/ibm_sv_restore_cloud_backup.py
@@ -48,7 +48,7 @@ options:
         type: str
     target_volume_name:
         description:
-            - Specifies the volume name to restore onto.
+            - Specifies the volume name/UID to restore onto.
         type: str
         required: true
     source_volume_uid:

--- a/plugins/modules/ibm_svc_host.py
+++ b/plugins/modules/ibm_svc_host.py
@@ -214,7 +214,7 @@ EXAMPLES = '''
     username: "{{ username }}"
     password: "{{ password }}"
     log_path: /tmp/playbook.debug
-    name: host4test
+    name: iscsi_host0
     state: present
     iscsiname: iqn.1994-05.com.redhat:2e358e438b8a
     iogrp: 0:1:2:3
@@ -229,7 +229,7 @@ EXAMPLES = '''
     username: "{{ username }}"
     password: "{{ password }}"
     log_path: /tmp/playbook.debug
-    name: host4test
+    name: host0
     state: present
     hostcluster: hostcluster0
 - name: Define a new FC host
@@ -239,7 +239,7 @@ EXAMPLES = '''
     username: "{{ username }}"
     password: "{{ password }}"
     log_path: /tmp/playbook.debug
-    name: host4test
+    name: fc_host0
     state: present
     fcwwpn: 100000109B570216:1000001AA0570266
     iogrp: 0:1:2:3
@@ -252,7 +252,7 @@ EXAMPLES = '''
     domain: "{{ domain }}"
     username: "{{ username }}"
     password: "{{ password }}"
-    old_name: "host4test"
+    old_name: "old_host_name"
     name: "new_host_name"
     state: "present"
 - name: Create an iSCSI host
@@ -262,7 +262,7 @@ EXAMPLES = '''
     username: "{{ username }}"
     password: "{{ password }}"
     log_path: /tmp/playbook.debug
-    name: host_name
+    name: iscsi_host0
     iscsiname: iqn.1994-05.com.redhat:2e358e438b8a,iqn.localhost.hostid.7f000001
     state: present
 - name: Create a tcpnvme host
@@ -272,7 +272,7 @@ EXAMPLES = '''
     username: "{{ username }}"
     password: "{{ password }}"
     log_path: /tmp/playbook.debug
-    name: host_name
+    name: tcpnvme_host0
     protocol: tcpnvme
     nqn: nqn.2014-08.org.nvmexpress:NVMf:uuid:644f51bf-8432-4f59-bb13-5ada20c06397
     state: present
@@ -283,7 +283,7 @@ EXAMPLES = '''
     username: "{{ username }}"
     password: "{{ password }}"
     log_path: /tmp/playbook.debug
-    name: new_host_name
+    name: host0
     state: absent
 - name: Add existing host to draft partition
   ibm.storage_virtualize.ibm_svc_host:
@@ -292,7 +292,7 @@ EXAMPLES = '''
     username: "{{ username }}"
     password: "{{ password }}"
     log_path: /tmp/playbook.debug
-    name: host_name
+    name: host0
     state: prersent
     draftpartition: partition_name
 - name: Remove a host from a draft partition
@@ -302,7 +302,7 @@ EXAMPLES = '''
     username: "{{ username }}"
     password: "{{ password }}"
     log_path: /tmp/playbook.debug
-    name: host_name
+    name: host0
     state: present
     nodraftpartition: 'True'
 - name: Create a fcnvme host
@@ -312,7 +312,7 @@ EXAMPLES = '''
     username: "{{ username }}"
     password: "{{ password }}"
     log_path: /tmp/playbook.debug
-    name: host_name
+    name: fcnvme_host0
     protocol: fcnvme
     nqn: nqn.2014-08.org.nvmexpress:b2071fa4-4356-410f-a4ae-7ebfab5b0e90
     portset: portset_name
@@ -324,7 +324,7 @@ EXAMPLES = '''
     username: "{{ username }}"
     password: "{{ password }}"
     log_path: /tmp/playbook.debug
-    name: ansible_host
+    name: fdmi_host0
     fdminame: Ansible-Host-1
     state: present
 - name: Create a host with preferred location.
@@ -352,6 +352,30 @@ EXAMPLES = '''
     state: present
     name: host0
     site: ""
+- name: Create a fcnvme host inside a partition
+  ibm.storage_virtualize.ibm_svc_host:
+    clustername: "{{ clustername }}"
+    domain: "{{ domain }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    log_path: /tmp/playbook.debug
+    name: fcnvme_host0
+    protocol: fcnvme
+    nqn: nqn.2014-08.org.nvmexpress:b2071fa4-4356-410f-a4ae-7ebfab5b0e90
+    portset: postset0
+    state: present
+- name: Create a tcpnvme host inside a partition
+  ibm.storage_virtualize.ibm_svc_host:
+    clustername: "{{ clustername }}"
+    domain: "{{ domain }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    log_path: /tmp/playbook.debug
+    name: tcpnvme_host0
+    protocol: tcpnvme
+    nqn: nqn.2014-08.org.nvmexpress:b2071fa4-4356-410f-a4ae-7ebfab5b0e90
+    portset: postset0
+    state: present
 '''
 
 RETURN = '''#'''

--- a/plugins/modules/ibm_svc_initial_setup.py
+++ b/plugins/modules/ibm_svc_initial_setup.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2021 IBM CORPORATION
 # Author(s): Shilpi Jain <shilpi.jain1@ibm.com>
 #            Lavanya C R <lavanya.c.r1@ibm.com>
+#            Sandip Gulab Rajbanshi <sandip.rajbanshi@ibm.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -167,9 +168,27 @@ options:
         type: str
         version_added: 2.6.0
         choices: [ 'yes', 'no' ]
+    anomalysnapshot:
+        description:
+            - Specifies whether a volume group snapshot will be triggered in case of Ransomware Threat Detection (RTD).
+        type: str
+        version_added: 3.3.0
+        choices: [ 'on', 'off' ]
+    anomalysnapshotretentiondays:
+        description:
+            - Indicates the retention in days to be used for the volume group snapshot created in case of RTD.
+        type: int
+        version_added: 3.3.0
+    latestsnapshotextensiondays:
+        description:
+            - Specifies number of extension days to be applied to the latest valid volume group snapshot's retention in
+              case of RTD.
+        type: int
+        version_added: 3.3.0
 author:
     - Shilpi Jain (@Shilpi-J)
     - Lavanya C R (@lavanyacr)
+    - Sandip Gulab Rajbanshi (@Sandip-Rajbanshi)
 notes:
     - This module supports C(check_mode).
     - Error Considerations
@@ -253,6 +272,14 @@ EXAMPLES = '''
     log_path: /tmp/playbook.debug
     iscsiauthmethod: none
     chapsecret: ""
+- name: Turn on anomalysnapshot, set retentiondays to 5 days and extend latest valid snapshot to 8 days.
+  ibm.storage_virtualize.ibm_svc_initial_setup:
+    clustername: "{{ clustername }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    anomalysnapshot: 'on'
+    anomalysnapshotretentiondays: 5
+    latestsnapshotextensiondays: 8
 '''
 
 RETURN = '''#'''
@@ -290,6 +317,9 @@ class IBMSVCInitialSetup(object):
                 easytier=dict(type='int'),
                 encryption=dict(type='str', choices=['on', 'off']),
                 cloud=dict(type='int'),
+                anomalysnapshot=dict(type='str', choices=['on', 'off']),
+                anomalysnapshotretentiondays=dict(type='int'),
+                latestsnapshotextensiondays=dict(type='int')
             )
         )
 
@@ -330,6 +360,11 @@ class IBMSVCInitialSetup(object):
         self.easytier = self.module.params.get('easytier', '')
         self.cloud = self.module.params.get('cloud', '')
         self.encryption = self.module.params.get('encryption', '')
+
+        # anomalysnapshot related parameters
+        self.anomalysnapshot = self.module.params.get('anomalysnapshot', '')
+        self.anomalysnapshotretentiondays = self.module.params.get('anomalysnapshotretentiondays', '')
+        self.latestsnapshotextensiondays = self.module.params.get('latestsnapshotextensiondays', '')
 
         self.restapi = IBMSVCRestApi(
             module=self.module,
@@ -645,6 +680,25 @@ class IBMSVCInitialSetup(object):
         else:
             self.message += " No license Changes."
 
+    def anomaly_setup(self):
+        cmdopts = {}
+        if self.anomalysnapshot:
+            cmdopts['anomalysnapshot'] = self.anomalysnapshot
+        if self.anomalysnapshotretentiondays:
+            cmdopts['anomalysnapshotretentiondays'] = self.anomalysnapshotretentiondays
+        if self.latestsnapshotextensiondays:
+            cmdopts['latestsnapshotextensiondays'] = self.latestsnapshotextensiondays
+
+        if self.module.check_mode:
+            self.changed = True
+            return
+
+        self.restapi.svc_run_command(
+            'chanomalydetection', cmdopts, None)
+        self.changed = True
+        self.log("Anomaly snapshot configuration updated: %s", cmdopts)
+        self.message += " Anomaly snapshot configuration updated."
+
     def apply(self):
         msg = None
         modify = []
@@ -672,6 +726,10 @@ class IBMSVCInitialSetup(object):
         if self.license_key:
             feature_data = self.get_feature_info()
             self.license_key_update(feature_data)
+
+        # For anomaly snapshot configuration
+        if self.anomalysnapshot or self.anomalysnapshotretentiondays or self.latestsnapshotextensiondays:
+            self.anomaly_setup()
 
         if self.changed:
             if self.module.check_mode:

--- a/plugins/modules/ibm_svc_manage_cv.py
+++ b/plugins/modules/ibm_svc_manage_cv.py
@@ -30,7 +30,7 @@ options:
     type: str
   cvname:
     description:
-      - Specifies the name to assign to the master or auxiliary change volume.
+      - Specifies the name to assign or UID to manage to the master or auxiliary change volume.
     required: true
     type: str
   basevolume:

--- a/plugins/modules/ibm_svc_manage_flashcopy.py
+++ b/plugins/modules/ibm_svc_manage_flashcopy.py
@@ -65,12 +65,12 @@ options:
         type: str
     source:
         description:
-            - Specifies the name of the source volume.
+            - Specifies the name/UID of the source volume.
             - Required when I(state=present), to create a FlashCopy mapping.
         type: str
     target:
         description:
-            - Specifies the name of the target volume.
+            - Specifies the name/UID of the target volume.
             - Required when I(state=present), to create a FlashCopy mapping.
         type: str
     mdiskgrp:

--- a/plugins/modules/ibm_svc_manage_ip.py
+++ b/plugins/modules/ibm_svc_manage_ip.py
@@ -339,7 +339,7 @@ class IBMSVCIp(object):
             props['gateway'] = self.gateway
         if self.resetgateway and data['gateway']:
             props['gateway'] = ""
-        if self.vlan and (self.vlan != data['vlan']):
+        if isinstance(self.vlan, int) and (self.vlan != (int(data.get('vlan') or 0))):
             props['vlan'] = self.vlan
         if self.resetvlan and data['vlan']:
             props['vlan'] = ""
@@ -397,16 +397,22 @@ class IBMSVCIp(object):
         ip_data = None
         if self.old_ip_address:
             if self.old_ip_address == self.ip_address:
-                ip_data = self.get_ip_info(self.old_ip_address)
+                self.old_ip_address = None
+
+            old_data = self.get_ip_info(self.old_ip_address) if self.old_ip_address else None
+            new_data = self.get_ip_info(self.ip_address)
+
+            if old_data and new_data:
+                self.module.fail_json(msg="Both IP '{0}' and '{1}' exist. Cannot update IP address.".format(self.old_ip_address, self.ip_address))
+
+            if not old_data:
+                if not new_data:
+                    self.module.fail_json(msg="IP '{0}' does not exist.".format(self.old_ip_address))
+
+                self.log("IP '%s' already exists. Continuing updates on it.", self.ip_address)
+                ip_data = new_data
             else:
-                old_data = self.get_ip_info(self.old_ip_address)
-                new_data = self.get_ip_info(self.ip_address)
-                if not old_data:
-                    self.module.fail_json(msg="Ip address [{0}] does not exists.".format(self.old_ip_address))
-                elif new_data:
-                    self.module.fail_json(msg="Ip address [{0}] already exists.".format(self.ip_address))
-                else:
-                    ip_data = old_data
+                ip_data = old_data
         else:
             ip_data = self.get_ip_info(self.ip_address)
 

--- a/plugins/modules/ibm_svc_manage_migration.py
+++ b/plugins/modules/ibm_svc_manage_migration.py
@@ -32,12 +32,12 @@ options:
     version_added: '1.11.0'
   source_volume:
     description:
-    - Specifies the name of the existing source volume to be used in migration.
+    - Specifies the name/UID of the existing source volume to be used in migration.
     - Required when I(state=initiate) or I(state=cleanup) or I(type_of_migration=across_pools).
     type: str
   target_volume:
     description:
-    - Specifies the name of the volume to be created on the target system.
+    - Specifies the name/UID of the volume to be created on the target system.
     - Required when I(state=initiate).
     type: str
   clustername:

--- a/plugins/modules/ibm_svc_manage_mirrored_volume.py
+++ b/plugins/modules/ibm_svc_manage_mirrored_volume.py
@@ -19,7 +19,7 @@ version_added: "1.4.0"
 options:
   name:
     description:
-      - Specifies the name to assign to the new volume.
+      - Specifies the name/UID to assign to the new volume.
     required: true
     type: str
   state:

--- a/plugins/modules/ibm_svc_manage_volume.py
+++ b/plugins/modules/ibm_svc_manage_volume.py
@@ -20,7 +20,7 @@ version_added: "1.6.0"
 options:
   name:
     description:
-      - Specifies the name to assign to the new volume.
+      - Specifies the name to assign to the new volume or name/UID to manage an existing volume.
     required: true
     type: str
   state:
@@ -102,7 +102,7 @@ options:
     type: str
   fromsourcevolume:
     description:
-      - Specifies the volume name in the snapshot used to pre-populate clone or thinclone volume.
+      - Specifies the volume name/UID in the snapshot used to pre-populate clone or thinclone volume.
       - Valid when I(state=present), to create a thinclone or clone volume.
       - Supported from Storage Virtualize family systems from 8.6.2.0 or later.
     type: str
@@ -147,7 +147,7 @@ options:
     version_added: 2.7.0
   old_name:
     description:
-      - Specifies the old name of the volume during renaming.
+      - Specifies the old name/UID of the volume during renaming.
       - Valid when I(state=present), to rename an existing volume.
     type: str
     version_added: '1.9.0'
@@ -1058,7 +1058,10 @@ class IBMSVCvolume(object):
         if not old_volume_data and not volume_data:
             self.module.fail_json(msg="Volume [{0}] does not exists.".format(self.old_name))
         elif old_volume_data and volume_data:
-            self.module.fail_json(msg="Volume [{0}] already exists.".format(self.name))
+            if old_volume_data[0].get('vdisk_UID') == volume_data[0].get('vdisk_UID'):
+                msg = "Volume [{0}] already renamed.".format(self.name)
+            else:
+                self.module.fail_json(msg="Volume [{0}] already exists.".format(self.name))
         elif not old_volume_data and volume_data:
             msg = "Volume with name [{0}] already exists.".format(self.name)
         elif old_volume_data and not volume_data:

--- a/plugins/modules/ibm_svc_manage_volumegroup.py
+++ b/plugins/modules/ibm_svc_manage_volumegroup.py
@@ -207,7 +207,7 @@ options:
         version_added: 2.2.0
     fromsourcevolumes:
         description:
-            - Specifies colon-separated list of the parent volumes.
+            - Specifies colon-separated list of the parent volumes name/UID.
             - When combined with the type parameter and a snapshot, this allows the user to create a volumegroup with a
               subset of those volumes whose image is present in a snapshot.
             - Applies when I(state=present) to create volumegroup clone or thinclone, from subset of volumes of snapshot.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added support for addressing volume via UID in volume, volumegroup, host,
        clone, mirror volume, migration, cloud_backup, flashcopy, snapshot, and vol_map modules,
        added playbook for Fibre Channel zoning for Cisco SAN switches.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
1. ibm_svc_manage_ip - Fixed issue related to VLAN while updating
- Feature Pull Request
1. ibm_svc_initial_setup - Added support for managing anomaly settings
2. ibm_svc_manage_volume - Added support for addressing volume via UID

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ibm.storage_virtualize

```