### PR TITLE
Replace ansible.module_utils.six with Python stdlib equivalents

### DIFF
--- a/changelogs/fragments/remove-module-utils-six.yml
+++ b/changelogs/fragments/remove-module-utils-six.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Replace the deprecated ``ansible.module_utils.six`` compatibility shims with
+    their Python standard library equivalents. ``ansible.module_utils.six`` is
+    deprecated in ansible-core 2.21 and is scheduled for removal in 2.24.

--- a/plugins/module_utils/ibm_svc_utils.py
+++ b/plugins/module_utils/ibm_svc_utils.py
@@ -15,10 +15,10 @@ import logging
 from uuid import UUID, getnode
 import inspect
 from time import sleep
+from urllib.parse import quote
+from urllib.error import HTTPError
 
 from ansible.module_utils.urls import open_url
-from ansible.module_utils.six.moves.urllib.parse import quote
-from ansible.module_utils.six.moves.urllib.error import HTTPError
 
 COLLECTION_VERSION = "3.4.0"
 TIMEOUT = 600


### PR DESCRIPTION
##### SUMMARY

`ansible.module_utils.six` is deprecated in ansible-core 2.21 and scheduled for removal in 2.24. The only two uses in this collection are urllib re-exports in `ibm_svc_utils.py`:

```python
-from ansible.module_utils.six.moves.urllib.parse import quote
-from ansible.module_utils.six.moves.urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.error import HTTPError
```

On Python 3 these are the identical stdlib objects, so `quote()` in `_svc_rest()` and the `except HTTPError` handler behave exactly as before. A changelog fragment is included.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

plugins/module_utils/ibm_svc_utils.py
